### PR TITLE
Migrate to chodeus-ops (phase 1)

### DIFF
--- a/.github/workflows/repo-events.yml
+++ b/.github/workflows/repo-events.yml
@@ -1,0 +1,20 @@
+# Drop into .github/workflows/repo-events.yml of ANY repo.
+# Fires Discord for: issue open/close, PR open/close/merge, release publish, discussion.
+# Workflow-failure notifications are handled inline by the failing caller workflow (see caller-docker.yml).
+
+name: Repo events
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+  release:
+    types: [published]
+  discussion:
+    types: [created]
+
+jobs:
+  notify:
+    uses: chodeus/chodeus-ops/workflows/repo-events.yml@main
+    secrets: inherit

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>chodeus/chodeus-ops"]
+}


### PR DESCRIPTION
## Summary

Adopts shared ops infra from [chodeus/chodeus-ops](https://github.com/chodeus/chodeus-ops). Minimal / low-risk.

- **`.github/workflows/repo-events.yml`** — calls chodeus-ops reusable for issue/PR/release Discord notifications.
- **`renovate.json`** — extends the `chodeus-ops` Renovate preset.

## Not in this PR (phase 2)

A CodeQL caller will be added in a follow-up PR. This repo's 10 existing workflows are release-focused for the Lidarr plugin and stay in place.

## Test plan

- [ ] Merge
- [ ] Open + close any issue — Discord posts both events
- [ ] Renovate Dependency Dashboard appears in ~10 min
- [ ] Existing release workflows untouched

## Rollback

`git revert` — 2 new files only.