### PR TITLE
fix(ci): build.yml YAML syntax on global.json step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,8 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Pin SDK via global.json
-        run: echo '{"sdk":{"version": "${{ env.DOTNET_VERSION }}"}}' > ./global.json
+        run: |
+          echo '{"sdk":{"version": "${{ env.DOTNET_VERSION }}"}}' > ./global.json
 
       - name: Write release notes file (msbuild property)
         env:


### PR DESCRIPTION
Workflow dispatch failed with 'yaml syntax on line 224'. Plain-scalar `run:` with inline JSON containing `${{ }}` expansion is ambiguous to GitHub's YAML parser — switching to block scalar.