### PR TITLE
ci: add actionlint self-validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,7 +316,7 @@ jobs:
 
           (
             cd "$PLUGIN_OUTPUT_DIR"
-            find . -name "*.${PLUGIN_NAME}.*" -o -name "*.Plugin.${PLUGIN_NAME}.*" | xargs zip -r "$PACKAGE_PATH"
+            find . \( -name "*.${PLUGIN_NAME}.*" -o -name "*.Plugin.${PLUGIN_NAME}.*" \) -exec zip -r "$PACKAGE_PATH" {} +
             [ -f "release_notes.txt" ] && zip -r "$PACKAGE_PATH" release_notes.txt
           )
 

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,39 @@
+name: Validate workflows
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install actionlint
+        id: install
+        shell: bash
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash)
+          echo "exe=$PWD/actionlint" >> "$GITHUB_OUTPUT"
+
+      - name: Run actionlint
+        shell: bash
+        env:
+          # Skip shellcheck info/style findings; real bugs still fail.
+          SHELLCHECK_OPTS: --severity=warning
+        run: ${{ steps.install.outputs.exe }} -color


### PR DESCRIPTION
Adds actionlint to every PR touching `.github/workflows/**`. Matches chodeus-ops self-CI pattern. Extra valuable here given the YAML dispatch-time bug that bit us during the build.yml consolidation (chodeus/sleezer#15) — with this in place, that class of bug fails at PR time.