### PR TITLE
fix(deps): pin System.Text.Json to 8.x for net8.0 Lidarr compat

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>chodeus/chodeus-ops"]
+  "extends": ["github>chodeus/chodeus-ops"],
+  "packageRules": [
+    {
+      "description": "Pin System.Text.Json and friends to 8.x — 9+ needs a newer runtime than Lidarr (net8.0) provides; breaks plugin loading.",
+      "matchPackageNames": [
+        "System.Text.Json",
+        "System.IO.Pipelines"
+      ],
+      "allowedVersions": "<9.0.0"
+    }
+  ]
 }

--- a/src/Sleezer/Sleezer.csproj
+++ b/src/Sleezer/Sleezer.csproj
@@ -28,7 +28,11 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Shard.DownloadAssistant" Version="1.1.2" />
-		<PackageReference Include="System.Text.Json" Version="10.0.6" GeneratePathProperty="true" />
+		<!-- PIN: stay on 8.x while TargetFramework=net8.0. System.Text.Json 9+
+		     transitively brings System.IO.Pipelines 9+/10+, which Lidarr's
+		     net8.0 runtime cannot resolve; DryIoc silently fails to enumerate
+		     plugin types and the plugin is skipped with no UI error. -->
+		<PackageReference Include="System.Text.Json" Version="8.0.6" GeneratePathProperty="true" />
 		<PackageReference Include="Xabe.FFmpeg" Version="6.0.2" />
 		<PackageReference Include="Xabe.FFmpeg.Downloader" Version="6.0.2" />
 


### PR DESCRIPTION
## Summary

v1.1.1 shipped with a silently-broken plugin DLL. Renovate PR #9 bumped `System.Text.Json` 8.0.6 → 10.0.6, which transitively depends on `System.IO.Pipelines 10.0.0.0` — a BCL assembly Lidarr's net8.0 runtime does not ship. At plugin load time DryIoc's `GetAssemblyTypes()` throws `FileNotFoundException` enumerating the plugin's types, Lidarr silently skips registration, and the plugin vanishes from the UI.

User-visible symptoms: plugin files present in `/config/plugins/chodeus/sleezer/` but "Skipping provider of unknown type DeezerIndexerSettings / SlskdSettings" warnings on startup and no plugin in the UI.

## Changes

- `src/Sleezer/Sleezer.csproj`: revert `System.Text.Json` to `8.0.6` with a comment explaining why it must stay on 8.x while TargetFramework=net8.0.
- `renovate.json`: `packageRules` blocking `System.Text.Json` and `System.IO.Pipelines` above 9.0.0.

## Test plan

- [ ] Build succeeds: `dotnet build Sleezer.sln -c Release -p:NuGetAudit=false`
- [ ] Tag v1.1.2 after merge; confirm released zip has `System.Text.Json 8.0.6` in `Lidarr.Plugin.Sleezer.deps.json`
- [ ] Install v1.1.2 in Lidarr; confirm plugin appears in System → Plugins and indexers register

## Follow-up

Broader BCL-pin + CI smoke-load test will follow in a separate PR to catch this class of regression automatically.