### PR TITLE
chore(renovate): broaden BCL-surface regression guard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,24 @@
   "extends": ["github>chodeus/chodeus-ops"],
   "packageRules": [
     {
-      "description": "Pin System.Text.Json and friends to 8.x — 9+ needs a newer runtime than Lidarr (net8.0) provides; breaks plugin loading.",
+      "description": "Hard pin: System.Text.Json / System.IO.Pipelines must stay on 8.x while TargetFramework=net8.0. 9+ brings runtime assemblies Lidarr's host does not ship, and the plugin silently fails to load (DryIoc FileNotFoundException). See PR #20.",
       "matchPackageNames": [
         "System.Text.Json",
         "System.IO.Pipelines"
       ],
       "allowedVersions": "<9.0.0"
+    },
+    {
+      "description": "BCL + ASP.NET / DI runtime surface: require manual dashboard approval for any major bump. These packages ship with the .NET runtime Lidarr hosts us in (net8.0), so crossing majors is the same class of break as the System.Text.Json 10 incident. Minor/patch bumps still auto-merge.",
+      "matchPackageNames": [
+        "/^System\\./",
+        "/^Microsoft\\.Extensions\\./",
+        "/^Microsoft\\.Bcl\\./",
+        "/^Microsoft\\.NETCore\\./",
+        "/^Microsoft\\.AspNetCore\\./"
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Stacked on top of [#20](https://github.com/chodeus/sleezer/pull/20). Implements recommendation #1 from the v1.1.1 incident post-mortem: a broader Renovate guard across the whole BCL + ASP.NET runtime surface so the next equivalent to System.Text.Json-10-in-a-net8-host is caught before auto-merge.

## What this does

- Keeps the hard pin on `System.Text.Json` / `System.IO.Pipelines` from #20.
- Adds a second `packageRules` entry: any **major** bump on `System.*`, `Microsoft.Extensions.*`, `Microsoft.Bcl.*`, `Microsoft.NETCore.*`, `Microsoft.AspNetCore.*` is flagged for manual approval via Renovate's dependency dashboard.
- Minor / patch bumps on those packages still auto-merge normally.

## What this does *not* do

- It doesn't catch a 3rd-party package quietly pulling a BCL transitive forward. That needs the CI smoke-load test (separate follow-up PR).
- It doesn't cover SkiaSharp, DeezNET, Jint, etc — those are 3rd-party and not runtime-shipped, so bumps are safe by default.

## Review-base note

Base is `fix/system-text-json-compat`, not `main`, so the diff shows only the new rule. Once #20 merges GitHub will auto-retarget this to `main`.

## Test plan

- [ ] `packageRules` JSON validates (verified locally: `json.load` round-trips).
- [ ] Wait for Renovate dashboard to show next would-be major System.* bump as "awaiting approval" rather than opening an auto-merge PR.