### PR TITLE
chore(renovate): broaden BCL-surface regression guard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,24 @@
   "extends": ["github>chodeus/chodeus-ops"],
   "packageRules": [
     {
-      "description": "Pin System.Text.Json and friends to 8.x — 9+ needs a newer runtime than Lidarr (net8.0) provides; breaks plugin loading.",
+      "description": "Hard pin: System.Text.Json / System.IO.Pipelines must stay on 8.x while TargetFramework=net8.0. 9+ brings runtime assemblies Lidarr's host does not ship, and the plugin silently fails to load (DryIoc FileNotFoundException). See PR #20.",
       "matchPackageNames": [
         "System.Text.Json",
         "System.IO.Pipelines"
       ],
       "allowedVersions": "<9.0.0"
+    },
+    {
+      "description": "BCL + ASP.NET / DI runtime surface: require manual dashboard approval for any major bump. These packages ship with the .NET runtime Lidarr hosts us in (net8.0), so crossing majors is the same class of break as the System.Text.Json 10 incident. Minor/patch bumps still auto-merge.",
+      "matchPackageNames": [
+        "/^System\\./",
+        "/^Microsoft\\.Extensions\\./",
+        "/^Microsoft\\.Bcl\\./",
+        "/^Microsoft\\.NETCore\\./",
+        "/^Microsoft\\.AspNetCore\\./"
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Recommendation #1 from the v1.1.1 incident. Now that [#20](https://github.com/chodeus/sleezer/pull/20) merged, this layers on top as a separate PR (the original [#22](https://github.com/chodeus/sleezer/pull/22) was auto-closed when its base branch got deleted during #20's squash-merge — same content, fresh branch off main).

## What this does

- Keeps the hard pin on `System.Text.Json` / `System.IO.Pipelines` from #20.
- Flags any **major** bump on `System.*`, `Microsoft.Extensions.*`, `Microsoft.Bcl.*`, `Microsoft.NETCore.*`, `Microsoft.AspNetCore.*` for manual approval via Renovate's dependency dashboard.
- Minor / patch bumps on those packages still auto-merge normally.

## What this doesn't do

Doesn't catch a 3rd-party package transitively pulling a BCL major forward. That's the CI smoke-load test (recommendation #2, separate PR incoming).

## Test plan

- [ ] `renovate.json` JSON validates.
- [ ] Next would-be major `System.*` Renovate PR lands on the dashboard awaiting approval instead of auto-merging.