### PR TITLE
ci: add smoke-load test for plugin DLL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,6 +329,48 @@ jobs:
           unzip -l "$PACKAGE_PATH"
           echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
 
+      - name: Smoke-load packaged plugin
+        # Catches the v1.1.1-class regression where a dependency bump pulls
+        # in a BCL transitive (e.g. System.IO.Pipelines 10) that Lidarr's
+        # net8.0 host cannot resolve, and the plugin silently disappears
+        # from the UI. See tools/SmokeLoad/Program.cs for the mechanic.
+        env:
+          PACKAGE_NAME: ${{ steps.package.outputs.package_name }}
+        run: |
+          set -euo pipefail
+
+          PLUGIN_ZIP="$GITHUB_WORKSPACE/$PACKAGE_NAME"
+          if [ ! -f "$PLUGIN_ZIP" ]; then
+            echo "::error::Packaged zip not found at $PLUGIN_ZIP"
+            exit 1
+          fi
+
+          # Lidarr's built assemblies (Lidarr.Common, Lidarr.Core, Lidarr.Http
+          # and their transitive non-BCL deps) — Directory.Build.props routes
+          # LidarrProject outputs to _output/.
+          HOST_DIR="$GITHUB_WORKSPACE/_output"
+          if [ ! -d "$HOST_DIR" ]; then
+            echo "::error::Lidarr host runtime dir not found at $HOST_DIR"
+            exit 1
+          fi
+
+          STAGE=$(mktemp -d)
+          unzip -o "$PLUGIN_ZIP" -d "$STAGE"
+          PLUGIN_DLL="$STAGE/Lidarr.Plugin.$PLUGIN_NAME.dll"
+          if [ ! -f "$PLUGIN_DLL" ]; then
+            echo "::error::Plugin DLL not found in package after unzip: $PLUGIN_DLL"
+            ls -la "$STAGE"
+            exit 1
+          fi
+
+          # Build the tool outside the plugin solution so it doesn't drag in
+          # the Lidarr submodule.
+          dotnet build tools/SmokeLoad/SmokeLoad.csproj \
+            -c Release -p:NuGetAudit=false --nologo
+
+          dotnet run --project tools/SmokeLoad/SmokeLoad.csproj \
+            -c Release --no-build -- "$PLUGIN_DLL" "$HOST_DIR"
+
       - name: Upload plugin package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/tools/SmokeLoad/Program.cs
+++ b/tools/SmokeLoad/Program.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Sleezer.SmokeLoad;
+
+// Usage: SmokeLoad <plugin-dll-path> <lidarr-runtime-dir>
+//
+//   plugin-dll-path    The packaged Lidarr.Plugin.Sleezer.dll, extracted from
+//                      the release zip. This is the file Lidarr installs.
+//
+//   lidarr-runtime-dir A directory containing the Lidarr-host-provided
+//                      assemblies (Lidarr.Common.dll, Lidarr.Core.dll, etc.)
+//                      and whatever else Lidarr's net8.0 runtime ships. In
+//                      practice we point at ext/Lidarr's build output.
+//
+// What this simulates:
+//   Lidarr installs the plugin zip into /config/plugins/<owner>/<name>/ and
+//   loads it into its own process. Its DryIoc container calls
+//   Assembly.GetTypes() to discover injectable services (Registrator.
+//   RegisterMany in Container.cs:8023). If any type in the plugin references
+//   an assembly the host runtime cannot resolve, GetTypes() throws
+//   ReflectionTypeLoadException, DryIoc swallows it, and the plugin
+//   silently disappears from the UI.
+//
+// What this does:
+//   Loads the plugin into an AssemblyLoadContext whose resolver can ONLY
+//   see (a) BCL assemblies that ship with the CI runner's .NET 8 runtime,
+//   and (b) assemblies in lidarr-runtime-dir. Any BCL version mismatch
+//   (the v1.1.1 incident: plugin wanted System.IO.Pipelines 10, host has 8)
+//   fails the load, exit 1, CI red.
+//
+// Exit codes: 0 = plugin loads cleanly, 1 = load or GetTypes() failed.
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: SmokeLoad <plugin-dll> <lidarr-runtime-dir>");
+            return 2;
+        }
+
+        string pluginPath = Path.GetFullPath(args[0]);
+        string hostDir = Path.GetFullPath(args[1]);
+
+        if (!File.Exists(pluginPath))
+        {
+            Console.Error.WriteLine($"FAIL: plugin DLL not found: {pluginPath}");
+            return 1;
+        }
+        if (!Directory.Exists(hostDir))
+        {
+            Console.Error.WriteLine($"FAIL: host runtime dir not found: {hostDir}");
+            return 1;
+        }
+
+        Console.WriteLine($"plugin: {pluginPath}");
+        Console.WriteLine($"host:   {hostDir}");
+
+        AssemblyLoadContext ctx = new("PluginSmoke", isCollectible: false);
+        ctx.Resolving += (c, name) =>
+        {
+            string candidate = Path.Combine(hostDir, name.Name + ".dll");
+            if (File.Exists(candidate))
+                return c.LoadFromAssemblyPath(candidate);
+
+            // Fall through to default context (CI runner's BCL). Returning
+            // null lets .NET keep searching; if nothing resolves, it throws.
+            return null;
+        };
+
+        Assembly asm;
+        try
+        {
+            asm = ctx.LoadFromAssemblyPath(pluginPath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"FAIL: LoadFromAssemblyPath threw: {ex.GetType().Name}: {ex.Message}");
+            return 1;
+        }
+
+        try
+        {
+            Type[] types = asm.GetTypes();
+            Console.WriteLine($"OK: loaded {types.Length} types from {asm.FullName}");
+            return 0;
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            Console.Error.WriteLine("FAIL: GetTypes() threw ReflectionTypeLoadException");
+            Console.Error.WriteLine("Loader exceptions:");
+            HashSet<string> seen = [];
+            foreach (Exception? le in ex.LoaderExceptions ?? Array.Empty<Exception?>())
+            {
+                if (le == null)
+                    continue;
+                string msg = $"  - {le.GetType().Name}: {le.Message}";
+                if (seen.Add(msg))
+                    Console.Error.WriteLine(msg);
+            }
+            return 1;
+        }
+    }
+}

--- a/tools/SmokeLoad/SmokeLoad.csproj
+++ b/tools/SmokeLoad/SmokeLoad.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Minimal net8.0 console tool that loads the packaged plugin DLL and walks
+    its types, mimicking what Lidarr's DryIoc container does when registering
+    services. Any BCL/runtime version mismatch (the bug that broke v1.1.1)
+    surfaces here as a FileNotFoundException inside a ReflectionTypeLoadException,
+    instead of silently being swallowed by Lidarr's plugin loader.
+
+    NOT in Sleezer.sln — it is a build-time tool, not a shipped artefact.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Sleezer.SmokeLoad</RootNamespace>
+    <AssemblyName>Sleezer.SmokeLoad</AssemblyName>
+    <!-- Opt out of the repo-wide plugin-output path (the root
+         Directory.Build.props routes every csproj to _plugins/<tfm>/<name>/).
+         This is a build-time tool, not a Lidarr plugin. -->
+    <PluginProject>false</PluginProject>
+    <OutputPath>bin/$(Configuration)/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Recommendation #2 from the v1.1.1 incident. Renovate pin ([#20](https://github.com/chodeus/sleezer/pull/20)) and BCL guard ([#23](https://github.com/chodeus/sleezer/pull/23)) are *preventative* layers. This is the *detection* layer — an actual runtime load of the packaged plugin DLL in CI, mirroring what Lidarr's DryIoc container does on startup. Any BCL mismatch that slips past the other two layers surfaces here as a CI failure before the artifact is uploaded.

## How it works

1. New `tools/SmokeLoad/` — a ~100-line net8.0 console app that:
   - Loads `Lidarr.Plugin.Sleezer.dll` into an `AssemblyLoadContext` whose `Resolving` handler falls back to Lidarr's host assemblies in `_output/` and the CI runner's BCL 8.
   - Calls `asm.GetTypes()` — the same call [DryIoc.Registrator.RegisterMany](https://github.com/dadhi/DryIoc/blob/master/src/DryIoc/Container.cs) makes, and the one that silently swallowed the v1.1.1 `FileNotFoundException` for `System.IO.Pipelines 10`.
   - Exits non-zero on any load failure.

2. New CI step in `build.yml` between "Package plugin" and "Upload plugin package" — extracts the just-packaged zip, then runs the smoke-load. Broken artifacts never make it to the release.

## Design notes

- `tools/SmokeLoad/` is intentionally **outside** `Sleezer.sln` (per `CLAUDE.md`: only shipping files belong in the sln). It's a build-time tool, not a plugin artefact.
- It's also outside the `_plugins/<tfm>/<name>/` output path that the root `Directory.Build.props` routes every csproj to — explicit `<PluginProject>false</PluginProject>` + `<OutputPath>` overrides.
- Locally verified against `v1.1.1`'s broken DLL: the tool reports `ReflectionTypeLoadException` with `Could not load file or assembly 'System.IO.Pipelines, Version=10.0.0.0'` — exactly what Lidarr's runtime saw.

## Limitation

`build.yml` only runs on `push: tags: v*` and `workflow_call`, so this PR's CI run won't actually exercise the smoke-load step — just actionlint / the repo-events workflow. First real validation is the **next release tag**. If the smoke-load step itself has a bug, we'll find out by tagging v1.1.3. Acceptable risk — the step is small and the logic is verified locally.

## Test plan

- [ ] Actionlint passes on this PR.
- [ ] After merge, cut a dummy tag (e.g. `v1.1.3-rc1`) to validate the step end-to-end before the next real release. Alternatively, tag `v1.1.3` straight and accept a single possible re-release if the step itself is broken.
- [ ] Verify the step correctly **fails** if someone reintroduces a System.Text.Json 10-class regression — can be tested by cherry-picking the v1.1.1 csproj and tagging an rc.