### PR TITLE
fix(tidal): handle BTS manifests instead of dead-coded MPD check

### DIFF
--- a/src/Sleezer/TidalSharp/Downloading/StreamManifest.cs
+++ b/src/Sleezer/TidalSharp/Downloading/StreamManifest.cs
@@ -33,7 +33,7 @@ internal class StreamManifest
             MimeType = dashInfo.MimeType;
             SampleRate = dashInfo.AudioSamplingRate;
         }
-        else if (_manifestMimeType == ManifestMimeType.MPD)
+        else if (_manifestMimeType == ManifestMimeType.BTS)
         {
             // TODO: i haven't seen one of these myself so im just guessing based on tidalapi
 


### PR DESCRIPTION
## Summary
- The second branch in `StreamManifest`'s constructor (`src/Sleezer/TidalSharp/Downloading/StreamManifest.cs:36`) checked `ManifestMimeType.MPD` again — same value as the preceding `if`, so it was dead code.
- As a result, any Tidal track returned with a BTS manifest (`application/vnd.tidal.bts`) skipped both branches and threw `UnsupportedManifestException("Unknown manifest, this track can't be downloaded.")`, which surfaced in Lidarr as e.g. *"Couldn't add release ... to download queue.: Unknown manifest, this track can't be downloaded."*
- Fixed by changing the second branch's check to `ManifestMimeType.BTS`. The branch body (JSON parse of `urls`/`codecs`/`mimeType`/`encryptionType`) was already correct — it was the original intent per the in-code TODO referencing the tidalapi port.

## Test plan
- [ ] Re-queue a release that previously failed with the "Unknown manifest" error (e.g. *AFI - Crash Love (Deluxe) [FLAC (M4A) Lossless] [WEB]*) and confirm it enters the download queue.
- [ ] Spot-check a known-good MPD/DASH FLAC release still downloads, to confirm no regression in the MPD branch.
- [ ] Watch logs for any follow-up `BTS` errors — the BTS body is still untested by the original author per the existing TODO, so encryption-key/`encryptionType` handling may need further work on a separate release.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UpLgx8GFBVhXSmjVb7ujZ)_