### PR TITLE
fix(tidal): seed CountryCode for the bootstrap /sessions call

### DIFF
--- a/src/Sleezer/Indexers/Tidal/Tidal.cs
+++ b/src/Sleezer/Indexers/Tidal/Tidal.cs
@@ -259,7 +259,8 @@ namespace NzbDrone.Core.Indexers.Tidal
                     Settings.RefreshToken,
                     Settings.TokenType,
                     Settings.UserId,
-                    Settings.Expires).GetAwaiter().GetResult();
+                    Settings.Expires,
+                    Settings.CountryCode).GetAwaiter().GetResult();
                 _loadedAccessToken = Settings.AccessToken;
             }
             catch (Exception ex)

--- a/src/Sleezer/TidalSharp/Core.cs
+++ b/src/Sleezer/TidalSharp/Core.cs
@@ -115,7 +115,7 @@ public class TidalClient
     // path when Lidarr loads our plugin and hands us tokens out of its own
     // settings store. Skips file IO entirely; pairs with IPluginSettings-backed
     // token storage instead of the legacy lastUser.json flow.
-    public async Task LoadFromTokens(string accessToken, string refreshToken, string tokenType, long userId, DateTime expirationDate, CancellationToken token = default)
+    public async Task LoadFromTokens(string accessToken, string refreshToken, string tokenType, long userId, DateTime expirationDate, string countryCode = "", CancellationToken token = default)
     {
         long secondsRemaining = (long)Math.Max(0, (expirationDate - DateTime.UtcNow).TotalSeconds);
         var data = new OAuthTokenData
@@ -127,7 +127,7 @@ public class TidalClient
             ExpiresIn = secondsRemaining,
             Scope = "r_usr+w_usr+w_sub",
             ClientName = "device",
-            User = new OAuthTokenData.UserData { UserId = userId, CountryCode = "" }
+            User = new OAuthTokenData.UserData { UserId = userId, CountryCode = countryCode ?? "" }
         };
 
         var user = new TidalUser(data, jsonPath: null, isPkce: false, expirationDate);

--- a/src/Sleezer/TidalSharp/TidalUser.cs
+++ b/src/Sleezer/TidalSharp/TidalUser.cs
@@ -74,6 +74,11 @@ public class TidalUser
     public string TokenType => _data.TokenType;
 
     public long UserId => _data.UserId;
-    public string CountryCode => _sessionInfo?.CountryCode ?? "";
+    // Fall back to the OAuth token's user.countryCode before the /sessions
+    // bootstrap call has populated _sessionInfo. Tidal now rejects requests
+    // (including the /sessions call itself) that arrive without countryCode,
+    // so the very first request after a fresh login or token-restore needs a
+    // value from somewhere other than the not-yet-fetched session info.
+    public string CountryCode => _sessionInfo?.CountryCode ?? _data.User?.CountryCode ?? "";
     public string SessionID => _sessionInfo?.SessionId ?? "";
 }


### PR DESCRIPTION
## Summary
- Tidal's API now rejects requests that arrive without a `countryCode` query parameter — including the very `/sessions` call we use to bootstrap one. The result was a flood of `Tidal session looks expired (server said: "countryCode parameter missing"); attempting refresh` warnings followed by `Tidal still rejected request after token refresh ... user must re-authenticate`, all immediately after a successful device login that clearly already knew the country (`Tidal device login complete for user 208186726 ("AU")`).
- Root cause: `TidalUser.CountryCode` only read from `_sessionInfo`, which is `null` until that bootstrap `/sessions` call returns. The OAuth token response already carries `data.user.countryCode`, but it was thrown away. `Core.LoadFromTokens` made the same mistake on Lidarr restart, hard-coding `CountryCode = ""` even though `TidalIndexerSettings.CountryCode` had already persisted the value.

## Changes
- `TidalSharp/TidalUser.cs` — `CountryCode` falls back to `_data.User?.CountryCode` when `_sessionInfo` isn't populated yet, so the first request after login/restore goes out with the right value.
- `TidalSharp/Core.cs` — `LoadFromTokens` accepts a `countryCode` argument and seeds `OAuthTokenData.UserData.CountryCode` instead of `""`. Default-valued for source compatibility.
- `Indexers/Tidal/Tidal.cs` — `EnsureTokensLoaded` passes `Settings.CountryCode` into `LoadFromTokens` so the persisted value is actually used.

The defensive `"countryCode parameter missing"` → expired-session heuristic in `API.cs` is left in place for now: it only triggers when `_activeUser.CountryCode` is non-empty, so it no longer fires falsely on bootstrap, and we keep one fallback layer for any future Tidal misbehaviour.

## Test plan
- [ ] Fresh device-flow login → indexer search succeeds without any `"countryCode parameter missing"` warnings.
- [ ] Restart Lidarr with persisted tokens (settings already include `CountryCode`) → indexer search succeeds without the warning loop.
- [ ] Wipe `Settings.CountryCode` only, restart → confirm graceful failure (single APIException, no infinite refresh loop).
- [ ] Confirm an actual expired token still surfaces as a real "expired" message and triggers exactly one refresh.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UpLgx8GFBVhXSmjVb7ujZ)_