### PR TITLE
fix(slskd): search, matching, and multi-disc overhaul from live-log audit

### DIFF
--- a/src/Sleezer/Core/Model/AlbumData.cs
+++ b/src/Sleezer/Core/Model/AlbumData.cs
@@ -38,6 +38,7 @@ namespace NzbDrone.Plugin.Sleezer.Core.Model
         public long? Size { get; set; }
 
         public int Priotity { get; set; }
+        public bool MatchedSearchCriteria { get; set; }
         public List<string>? ExtraInfo { get; set; }
 
         public string DownloadProtocol { get; set; } = downloadProtocol;
@@ -48,22 +49,39 @@ namespace NzbDrone.Plugin.Sleezer.Core.Model
         /// <summary>
         /// Converts AlbumData into a ReleaseInfo object.
         /// </summary>
-        public ReleaseInfo ToReleaseInfo() => new()
+        public ReleaseInfo ToReleaseInfo() => FillReleaseInfo(new ReleaseInfo());
+
+        /// <summary>
+        /// Slskd variant of <see cref="ToReleaseInfo"/>. ShareInfo derives from
+        /// TorrentInfo so the share priority reaches
+        /// SlskdIndexer.CleanupReleases as Seeders; a plain ReleaseInfo made
+        /// that hook dead code and every release ranked on quality alone.
+        /// </summary>
+        public ShareInfo ToShareInfo()
         {
-            Guid = Guid ?? $"{IndexerName}-{AlbumId}-{Codec}-{Bitrate}-{BitDepth}",
-            Artist = ArtistName,
-            Album = AlbumName,
-            DownloadUrl = AlbumId,
-            InfoUrl = InfoUrl,
-            PublishDate = ReleaseDateTime == DateTime.MinValue ? DateTime.UtcNow : ReleaseDateTime,
-            DownloadProtocol = DownloadProtocol,
-            Title = ConstructTitle(),
-            Codec = Codec.ToString(),
-            Resolution = CoverResolution,
-            Source = CustomString,
-            Container = Bitrate.ToString(),
-            Size = Size ?? (Duration > 0 ? Duration : TotalTracks * 300) * Bitrate * 1000 / 8
-        };
+            ShareInfo release = (ShareInfo)FillReleaseInfo(new ShareInfo());
+            release.Seeders = Priotity;
+            release.MatchedSearchCriteria = MatchedSearchCriteria;
+            return release;
+        }
+
+        private ReleaseInfo FillReleaseInfo(ReleaseInfo release)
+        {
+            release.Guid = Guid ?? $"{IndexerName}-{AlbumId}-{Codec}-{Bitrate}-{BitDepth}";
+            release.Artist = ArtistName;
+            release.Album = AlbumName;
+            release.DownloadUrl = AlbumId;
+            release.InfoUrl = InfoUrl;
+            release.PublishDate = ReleaseDateTime == DateTime.MinValue ? DateTime.UtcNow : ReleaseDateTime;
+            release.DownloadProtocol = DownloadProtocol;
+            release.Title = ConstructTitle();
+            release.Codec = Codec.ToString();
+            release.Resolution = CoverResolution;
+            release.Source = CustomString;
+            release.Container = Bitrate.ToString();
+            release.Size = Size ?? (Duration > 0 ? Duration : TotalTracks * 300) * Bitrate * 1000 / 8;
+            return release;
+        }
 
         /// <summary>
         /// Parses the release date based on the precision.

--- a/src/Sleezer/Core/Model/ShareInfo.cs
+++ b/src/Sleezer/Core/Model/ShareInfo.cs
@@ -1,0 +1,21 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Plugin.Sleezer.Core.Model
+{
+    /// <summary>
+    /// ReleaseInfo for a Soulseek share. Derives from TorrentInfo so the
+    /// computed share priority can ride in <see cref="TorrentInfo.Seeders"/>,
+    /// which SlskdIndexer.CleanupReleases folds into IndexerPriority — the
+    /// ranking signal Lidarr's decision comparer actually consumes. Plain
+    /// ReleaseInfo silently discarded the priority entirely.
+    /// </summary>
+    public class ShareInfo : TorrentInfo
+    {
+        /// <summary>
+        /// True when the source directory fuzzy-matched the searched
+        /// artist/album. Tiered search uses this to decide whether a tier
+        /// actually found the wanted album or just returned bystander folders.
+        /// </summary>
+        public bool MatchedSearchCriteria { get; set; }
+    }
+}

--- a/src/Sleezer/Core/Replacements/ExtendedHttpIndexerBase.cs
+++ b/src/Sleezer/Core/Replacements/ExtendedHttpIndexerBase.cs
@@ -125,9 +125,15 @@ namespace NzbDrone.Plugin.Sleezer.Core.Replacements
 
                     releases.AddRange(tierReleases);
 
-                    if (pageableRequestChain.AreTierResultsUsable(i, tierReleases.Count))
+                    // Only releases that matched the search criteria count toward
+                    // the stop decision. A tier full of bystander directories
+                    // (parsed but not matching the wanted artist/album) must not
+                    // suppress the broader recovery tiers behind it.
+                    int matchedCount = tierReleases.Count(r => r is not Model.ShareInfo share || share.MatchedSearchCriteria);
+
+                    if (pageableRequestChain.AreTierResultsUsable(i, matchedCount))
                     {
-                        _logger.Debug($"Tier {i + 1} found {tierReleases.Count} usable results out of total {releases.Count} results. Stopping search.");
+                        _logger.Debug($"Tier {i + 1} found {matchedCount} matching results ({tierReleases.Count} parsed) out of total {releases.Count} results. Stopping search.");
                         break;
                     }
                     else if (tierReleases.Count != 0)

--- a/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
@@ -29,23 +29,22 @@ public class SlskdDownloadItem
 
     public event EventHandler<SlskdFileState>? FileStateChanged;
 
-    private SlskdDownloadDirectory? _slskdDownloadDirectory;
+    // A multi-disc release spans several remote directories (Album\CD1,
+    // Album\CD2); slskd reports transfers per remote directory, so the item
+    // aggregates them and exposes a merged view through SlskdDownloadDirectory.
+    private readonly Dictionary<string, SlskdDownloadDirectory> _remoteDirectories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _enqueuedFilenames;
     private readonly Dictionary<string, SlskdFileState> _previousFileStates = [];
 
     public List<Task> PostProcessTasks { get; } = [];
     public DownloadItemStatus? LastReportedStatus { get; set; }
+    public bool DiscFoldersMerged { get; set; }
     public IReadOnlyDictionary<string, SlskdFileState> FileStates => _previousFileStates;
 
     public SlskdDownloadDirectory? SlskdDownloadDirectory
     {
-        get => _slskdDownloadDirectory;
-        set
-        {
-            if (_slskdDownloadDirectory == value)
-                return;
-            CompareFileStates(value);
-            _slskdDownloadDirectory = value;
-        }
+        get => BuildMergedDirectory();
+        set => AddOrUpdateDirectory(value);
     }
 
     public SlskdDownloadItem(ReleaseInfo releaseInfo)
@@ -54,7 +53,107 @@ public class SlskdDownloadItem
         ReleaseInfo = releaseInfo;
         FileData = JsonSerializer.Deserialize<List<SlskdFileData>>(ReleaseInfo.Source, _jsonOptions) ?? [];
         ID = GetStableMD5Id(FileData.Select(file => file.Filename));
+        _enqueuedFilenames = FileData
+            .Select(f => f.Filename)
+            .Where(f => !string.IsNullOrEmpty(f))
+            .Select(f => f!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         _logger.Trace("Created SlskdDownloadItem with ID: {Id}", ID);
+    }
+
+    /// <summary>True when this item enqueued the given remote file.</summary>
+    public bool OwnsFile(string? remoteFilename) =>
+        !string.IsNullOrEmpty(remoteFilename) && _enqueuedFilenames.Contains(remoteFilename);
+
+    /// <summary>True when this item tracks transfers for the given remote directory.</summary>
+    public bool TracksRemoteDirectory(string? remoteDirectory) =>
+        !string.IsNullOrEmpty(remoteDirectory) && _remoteDirectories.ContainsKey(remoteDirectory);
+
+    /// <summary>
+    /// True when the enqueued files span more than one remote directory
+    /// (multi-disc share with CD1/CD2 subfolders).
+    /// </summary>
+    public bool IsMultiDirectory => RemoteDirectoryLeaves().Count > 1;
+
+    /// <summary>
+    /// Leaf folder names of every remote directory the enqueued files live in
+    /// — these are the local folder names slskd downloads into.
+    /// </summary>
+    public IReadOnlyCollection<string> RemoteDirectoryLeaves()
+    {
+        HashSet<string> leaves = new(StringComparer.OrdinalIgnoreCase);
+        foreach (SlskdFileData file in FileData)
+        {
+            string dir = SlskdTextProcessor.GetDirectoryFromFilename(file.Filename);
+            string leaf = LeafOf(dir);
+            if (leaf.Length > 0)
+                leaves.Add(leaf);
+        }
+
+        return leaves;
+    }
+
+    /// <summary>
+    /// Local album folder name for a multi-disc item: the leaf of the common
+    /// remote parent directory (disc subfolders folded away). Falls back to the
+    /// item ID when the share layout gives no usable name.
+    /// </summary>
+    public string LocalAlbumFolderName()
+    {
+        HashSet<string> mergedKeys = new(StringComparer.OrdinalIgnoreCase);
+        foreach (SlskdFileData file in FileData)
+        {
+            string key = SlskdTextProcessor.GetMergedDirectoryKey(file.Filename);
+            if (!string.IsNullOrEmpty(key))
+                mergedKeys.Add(key);
+        }
+
+        string leaf = mergedKeys.Count == 1 ? LeafOf(mergedKeys.First()) : "";
+        return leaf is "" or "." or ".." ? ID : leaf;
+    }
+
+    private static string LeafOf(string path)
+    {
+        string trimmed = path.Replace('\\', '/').TrimEnd('/');
+        int idx = trimmed.LastIndexOf('/');
+        string leaf = idx >= 0 ? trimmed[(idx + 1)..] : trimmed;
+        return leaf is "." or ".." ? "" : leaf;
+    }
+
+    private void AddOrUpdateDirectory(SlskdDownloadDirectory? directory)
+    {
+        if (directory == null || string.IsNullOrEmpty(directory.Directory))
+            return;
+
+        if (_remoteDirectories.TryGetValue(directory.Directory, out SlskdDownloadDirectory? existing) && existing == directory)
+            return;
+
+        CompareFileStates(directory);
+        _remoteDirectories[directory.Directory] = directory;
+    }
+
+    private SlskdDownloadDirectory? BuildMergedDirectory()
+    {
+        if (_remoteDirectories.Count == 0)
+            return null;
+
+        if (_remoteDirectories.Count == 1)
+            return _remoteDirectories.Values.First();
+
+        List<SlskdDownloadFile> allFiles = _remoteDirectories.Values
+            .Where(d => d.Files != null)
+            .SelectMany(d => d.Files!)
+            .ToList();
+
+        // Fold each directory's disc-leaf away; when they all share one parent
+        // (the normal Album\CD1 + Album\CD2 case) report that parent.
+        List<string> mergedParents = _remoteDirectories.Keys
+            .Select(key => SlskdTextProcessor.GetMergedDirectoryKey(key + "\\x"))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        string commonParent = mergedParents.Count == 1 ? mergedParents[0] : _remoteDirectories.Keys.First();
+
+        return new SlskdDownloadDirectory(commonParent, allFiles.Count, allFiles);
     }
 
     public static string GetStableMD5Id(IEnumerable<string?> filenames)
@@ -98,6 +197,12 @@ public class SlskdDownloadItem
 
     public OsPath GetFullFolderPath(OsPath downloadPath)
     {
+        // Multi-disc: slskd downloads each remote disc directory into its own
+        // local folder; the manager merges those into one album folder after
+        // completion, and that folder is what Lidarr imports.
+        if (IsMultiDirectory)
+            return new OsPath(Path.Combine(downloadPath.FullPath, LocalAlbumFolderName()));
+
         string leaf = SlskdDownloadDirectory?.Directory
             .Replace('\\', '/')
             .TrimEnd('/')

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -633,7 +633,15 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                 // status stays Downloading until this task completes, so Lidarr
                 // cannot import mid-merge.
                 if (mergeNeeded)
+                {
                     TryMergeDiscFolders(item, settings);
+
+                    if (!item.DiscFoldersMerged)
+                    {
+                        _logger.Warn("[post-process] {ItemId}: skipping scan/tag — disc-folder merge incomplete", item.ID);
+                        return;
+                    }
+                }
 
                 OsPath remotePath = GetRemoteDownloadPath(settings);
                 string folderPath = item.GetFullFolderPath(remotePath).FullPath;
@@ -721,18 +729,32 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                 return;
             }
 
+            bool allMoved = true;
+
             foreach (string leaf in item.RemoteDirectoryLeaves())
             {
                 string source = Path.Combine(localRoot, leaf);
-                if (!IsStrictDescendantOfRoot(source, localRoot) || !_diskProvider.FolderExists(source))
+                if (!_diskProvider.FolderExists(source))
                     continue;
+
+                if (!IsStrictDescendantOfRoot(source, localRoot))
+                {
+                    allMoved = false;
+                    continue;
+                }
 
                 if (string.Equals(Path.GetFullPath(source), Path.GetFullPath(albumFolder), StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 string target = Path.Combine(albumFolder, leaf);
-                if (!IsStrictDescendantOfRoot(target, localRoot) || _diskProvider.FolderExists(target))
+                if (_diskProvider.FolderExists(target))
                     continue;
+
+                if (!IsStrictDescendantOfRoot(target, localRoot))
+                {
+                    allMoved = false;
+                    continue;
+                }
 
                 try
                 {
@@ -744,11 +766,17 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                 }
                 catch (Exception ex)
                 {
+                    allMoved = false;
                     _logger.Warn(ex, "[merge] {ItemId}: failed to move disc folder '{Source}'", item.ID, source);
                 }
             }
 
-            item.DiscFoldersMerged = true;
+            // A partial merge must NOT be recorded as merged: the flag guards
+            // both the post-process scan (which would see a disc missing) and
+            // TryDeleteUnmergedDiscFolders cleanup of the leftover folder.
+            item.DiscFoldersMerged = allMoved;
+            if (!allMoved)
+                _logger.Warn("[merge] {ItemId}: disc-folder merge incomplete; leaving unmerged folders in place", item.ID);
         }
         catch (Exception ex)
         {

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -252,6 +252,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         }
 
         TryDeleteOutputFolder(clientItem, settings);
+        TryDeleteUnmergedDiscFolders(item, settings);
 
         RemoveItemFromDict(definitionId, clientItem.DownloadId);
 
@@ -304,6 +305,35 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         catch (Exception ex)
         {
             _logger.Warn(ex, "[{Title}] Failed to delete output folder '{Folder}'", clientItem.Title, folder);
+        }
+    }
+
+    /// <summary>
+    /// Removes the per-disc local folders of a multi-disc item that was
+    /// cancelled or failed before the post-completion merge ran.
+    /// </summary>
+    private void TryDeleteUnmergedDiscFolders(SlskdDownloadItem item, SlskdProviderSettings settings)
+    {
+        if (!item.IsMultiDirectory || item.DiscFoldersMerged)
+            return;
+
+        string localRoot = GetRemoteDownloadPath(settings).FullPath.TrimEnd('/', '\\');
+
+        foreach (string leaf in item.RemoteDirectoryLeaves())
+        {
+            string folder = Path.Combine(localRoot, leaf);
+            if (!IsStrictDescendantOfRoot(folder, localRoot) || !_diskProvider.FolderExists(folder))
+                continue;
+
+            try
+            {
+                _logger.Debug("[{ItemId}] Deleting unmerged disc folder '{Folder}'", item.ID, folder);
+                _diskProvider.DeleteFolder(folder, true);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "[{ItemId}] Failed to delete unmerged disc folder '{Folder}'", item.ID, folder);
+            }
         }
     }
 
@@ -417,7 +447,11 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             string hash = SlskdDownloadItem.GetStableMD5Id(dir.Files?.Select(f => f.Filename) ?? []);
             currentIdSet.TryAdd(hash, true);
 
-            SlskdDownloadItem? item = GetItem(definitionId, hash);
+            // A multi-disc item's ID hashes ALL its files, but slskd reports
+            // transfers per remote directory — the per-directory hash never
+            // matches, so fall back to matching by enqueued-file membership.
+            SlskdDownloadItem? item = GetItem(definitionId, hash)
+                ?? FindItemOwningDirectory(definitionId, dir);
             if (item == null)
             {
                 _logger.Trace("[def={DefinitionId}] Unknown item {Hash}: checking history", definitionId, hash);
@@ -434,6 +468,10 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                 SubscribeStateChanges(item, definitionId);
                 AddItem(definitionId, item);
             }
+            else
+            {
+                currentIdSet.TryAdd(item.ID, true);
+            }
 
             item.Username ??= userTransfers.Username;
             item.SlskdDownloadDirectory = dir;
@@ -448,10 +486,24 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         }
     }
 
+    private SlskdDownloadItem? FindItemOwningDirectory(int definitionId, SlskdDownloadDirectory dir)
+    {
+        string? probeFile = dir.Files?.FirstOrDefault()?.Filename;
+        if (string.IsNullOrEmpty(probeFile))
+            return null;
+
+        return GetItemsForDef(definitionId).FirstOrDefault(i => i.OwnsFile(probeFile));
+    }
+
     private static bool AllFilesCompleted(SlskdDownloadItem item)
     {
         IReadOnlyDictionary<string, SlskdFileState> states = item.FileStates;
         if (states.Count == 0)
+            return false;
+
+        // Multi-disc: transfer state arrives per remote directory, so wait until
+        // every enqueued file has reported before declaring the album complete.
+        if (item.FileData.Count > 0 && states.Count < item.FileData.Count)
             return false;
 
         foreach (SlskdFileState state in states.Values)
@@ -504,11 +556,17 @@ public class SlskdDownloadManager : ISlskdDownloadManager
 
             SlskdDownloadItem? item = GetItemsForDef(definitionId)
                 .FirstOrDefault(i => i.Username == username &&
-                                     string.Equals(i.SlskdDownloadDirectory?.Directory, remoteDir, StringComparison.OrdinalIgnoreCase));
+                                     (i.TracksRemoteDirectory(remoteDir) ||
+                                      string.Equals(i.SlskdDownloadDirectory?.Directory, remoteDir, StringComparison.OrdinalIgnoreCase)));
 
             if (item != null)
             {
-                EnqueuePostProcess(item, settings);
+                // Multi-disc items get one DownloadDirectoryComplete per disc;
+                // only post-process once every enqueued file is done.
+                if (AllFilesCompleted(item))
+                    EnqueuePostProcess(item, settings);
+                else
+                    _logger.Trace("[def={DefinitionId}] Directory {RemoteDir} complete but item {ItemId} still has pending files — waiting", definitionId, remoteDir, item.ID);
             }
             else if (userTransfers == null)
             {
@@ -553,8 +611,9 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         FFmpegSettings? sharedSettings = GetSharedPostProcessingSettings();
         bool scanEnabled = sharedSettings?.CorruptionScanClients?.Contains((int)PostProcessClient.Slskd) ?? false;
         bool tagEnabled = sharedSettings?.PreImportTaggingClients?.Contains((int)PostProcessClient.Slskd) ?? false;
+        bool mergeNeeded = item.IsMultiDirectory && !item.DiscFoldersMerged;
 
-        if (!scanEnabled && !tagEnabled)
+        if (!scanEnabled && !tagEnabled && !mergeNeeded)
             return;
 
         Task task = Task.Run(async () =>
@@ -567,6 +626,15 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                 // finishes moving files out of the incomplete dir. Give it a moment.
                 await Task.Delay(TimeSpan.FromSeconds(5), cts.Token);
 
+                // Multi-disc: slskd downloaded each remote disc directory into
+                // its own local folder (CD1, CD2). Merge them into the album
+                // folder BEFORE scanning/importing — the item's OutputPath
+                // (GetFullFolderPath) already points at the merged folder, and
+                // status stays Downloading until this task completes, so Lidarr
+                // cannot import mid-merge.
+                if (mergeNeeded)
+                    TryMergeDiscFolders(item, settings);
+
                 OsPath remotePath = GetRemoteDownloadPath(settings);
                 string folderPath = item.GetFullFolderPath(remotePath).FullPath;
 
@@ -575,6 +643,9 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                     _logger.Warn("[post-process] Folder missing after DownloadDirectoryComplete: {FolderPath}", folderPath);
                     return;
                 }
+
+                if (!scanEnabled && !tagEnabled)
+                    return;
 
                 if (scanEnabled)
                 {
@@ -628,6 +699,61 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         });
 
         item.PostProcessTasks.Add(task);
+    }
+
+    /// <summary>
+    /// Moves the per-disc local folders slskd created (CD1, CD2, ...) into the
+    /// item's album folder, preserving the disc subfolders (Lidarr imports
+    /// multi-disc layouts fine as long as they share one root). Every move is
+    /// gated on the resolved paths being strict descendants of the download
+    /// root — disc leaf names are peer-controlled.
+    /// </summary>
+    private void TryMergeDiscFolders(SlskdDownloadItem item, SlskdProviderSettings settings)
+    {
+        try
+        {
+            string localRoot = GetRemoteDownloadPath(settings).FullPath.TrimEnd('/', '\\');
+            string albumFolder = item.GetFullFolderPath(new OsPath(localRoot)).FullPath;
+
+            if (!IsStrictDescendantOfRoot(albumFolder, localRoot))
+            {
+                _logger.Warn("[merge] Album folder '{Album}' is not inside the download root '{Root}', refusing disc merge", albumFolder, localRoot);
+                return;
+            }
+
+            foreach (string leaf in item.RemoteDirectoryLeaves())
+            {
+                string source = Path.Combine(localRoot, leaf);
+                if (!IsStrictDescendantOfRoot(source, localRoot) || !_diskProvider.FolderExists(source))
+                    continue;
+
+                if (string.Equals(Path.GetFullPath(source), Path.GetFullPath(albumFolder), StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string target = Path.Combine(albumFolder, leaf);
+                if (!IsStrictDescendantOfRoot(target, localRoot) || _diskProvider.FolderExists(target))
+                    continue;
+
+                try
+                {
+                    if (!_diskProvider.FolderExists(albumFolder))
+                        _diskProvider.CreateFolder(albumFolder);
+
+                    _logger.Debug("[merge] {ItemId}: moving disc folder '{Source}' -> '{Target}'", item.ID, source, target);
+                    _diskProvider.MoveFolder(source, target);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "[merge] {ItemId}: failed to move disc folder '{Source}'", item.ID, source);
+                }
+            }
+
+            item.DiscFoldersMerged = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "[merge] Disc-folder merge failed for {ItemId}", item.ID);
+        }
     }
 
     private async Task<List<SlskdCorruptionStrike>> ScanFolderForCorruptionAsync(
@@ -837,7 +963,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         SlskdSearchData searchData = new(null, null, false, false, 1, null);
         IGrouping<string, SlskdFileData> dirGroup = dir.ToSlskdFileDataList().GroupBy(_ => dir.Directory).First();
         AlbumData albumData = _slskdItemsParser.CreateAlbumData(string.Empty, dirGroup, searchData, folderData, null, 0);
-        ReleaseInfo release = albumData.ToReleaseInfo();
+        ReleaseInfo release = albumData.ToShareInfo();
         release.DownloadProtocol = null;
         return release;
     }

--- a/src/Sleezer/Indexers/Soulseek/Search/Core/QueryAnalyzer.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Core/QueryAnalyzer.cs
@@ -26,9 +26,6 @@ public static partial class QueryAnalyzer
         if (IsShortName(context.Album))
             type |= QueryType.ShortName;
 
-        if (NeedsTypeDisambiguation(context))
-            type |= QueryType.NeedsTypeDisambiguation;
-
         if (HasVolumeReference(context.Album))
             type |= QueryType.HasVolume;
 
@@ -82,32 +79,6 @@ public static partial class QueryAnalyzer
         if (string.IsNullOrWhiteSpace(album))
             return false;
         return album.Trim().Length < ShortNameThreshold;
-    }
-
-    public static bool NeedsTypeDisambiguation(SearchContext context)
-    {
-        if (context.PrimaryType != NzbDrone.Core.Music.PrimaryAlbumType.EP &&
-            context.PrimaryType != NzbDrone.Core.Music.PrimaryAlbumType.Single)
-            return false;
-
-        // Short names always need disambiguation
-        if (IsShortName(context.Album))
-            return true;
-
-        // Self-titled EPs/Singles need disambiguation
-        if (IsSelfTitled(context.Artist, context.Album))
-            return true;
-
-        // Common album-like names that could conflict
-        string? album = context.Album?.Trim();
-        if (string.IsNullOrEmpty(album))
-            return true;
-
-        // Single-word titles are ambiguous
-        if (!album.Contains(' '))
-            return true;
-
-        return false;
     }
 
     public static bool HasVolumeReference(string? album) =>

--- a/src/Sleezer/Indexers/Soulseek/Search/Core/SearchContext.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Core/SearchContext.cs
@@ -1,6 +1,5 @@
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.IndexerSearch.Definitions;
-using NzbDrone.Core.Music;
 
 namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Core;
 
@@ -13,8 +12,7 @@ public enum QueryType
     VariousArtists = 1 << 2,
     HasVolume = 1 << 3,
     HasRomanNumeral = 1 << 4,
-    NeedsNormalization = 1 << 5,
-    NeedsTypeDisambiguation = 1 << 6
+    NeedsNormalization = 1 << 5
 }
 
 public sealed record SearchContext
@@ -24,7 +22,6 @@ public sealed record SearchContext
     public string? Year { get; init; }
     public bool Interactive { get; init; }
     public int TrackCount { get; init; }
-    public PrimaryAlbumType PrimaryType { get; init; }
     public IReadOnlyList<string> Aliases { get; init; }
     public IReadOnlyList<string> Tracks { get; init; }
     public SlskdSettings Settings { get; init; }
@@ -43,14 +40,6 @@ public sealed record SearchContext
     public bool IsSelfTitled => QueryType.HasFlag(QueryType.SelfTitled);
     public bool IsShortName => QueryType.HasFlag(QueryType.ShortName);
     public bool HasValidYear => !string.IsNullOrEmpty(Year) && Year != "0";
-    public bool NeedsTypeDisambiguation => QueryType.HasFlag(QueryType.NeedsTypeDisambiguation);
-
-    public string? ReleaseTypeTag => PrimaryType switch
-    {
-        var t when t == PrimaryAlbumType.EP => "EP",
-        var t when t == PrimaryAlbumType.Single => "Single",
-        _ => null
-    };
 
     public SearchContext(
         string? Artist,
@@ -58,7 +47,6 @@ public sealed record SearchContext
         string? Year,
         bool Interactive,
         int TrackCount,
-        PrimaryAlbumType PrimaryType,
         IReadOnlyList<string> Aliases,
         IReadOnlyList<string> Tracks,
         SlskdSettings Settings,
@@ -70,7 +58,6 @@ public sealed record SearchContext
         this.Year = Year;
         this.Interactive = Interactive;
         this.TrackCount = TrackCount;
-        this.PrimaryType = PrimaryType;
         this.Aliases = Aliases;
         this.Tracks = Tracks;
         this.Settings = Settings;

--- a/src/Sleezer/Indexers/Soulseek/Search/Strategies/BaseSearchStrategy.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Strategies/BaseSearchStrategy.cs
@@ -21,11 +21,34 @@ public sealed class BaseSearchStrategy : SearchStrategyBase
                !string.IsNullOrWhiteSpace(context.SearchAlbum);
     }
 
-    // Build: Artist + Album + Year (if valid) + Type (if needed)
+    // Plain "Artist Album" — every term in a Soulseek query is mandatory, so
+    // year and release-type words belong in later variation tiers, not here
+    // (live logs: "Artist Album Year Single" first-queries were the top
+    // zero-result shape while the plain form often never ran).
     public override string? GetQuery(SearchContext context, QueryType queryType) =>
-        QueryBuilder.Build(
-            context.SearchArtist,
-            context.SearchAlbum,
-            context.Settings.AppendYear && context.HasValidYear ? context.Year : null,
-            context.NeedsTypeDisambiguation ? context.ReleaseTypeTag : null);
+        QueryBuilder.Build(context.SearchArtist, context.SearchAlbum);
+}
+
+public sealed class YearSearchStrategy : SearchStrategyBase
+{
+    public override string Name => "Year Search";
+    public override SearchTier Tier => SearchTier.Variation;
+    public override int Priority => -10;
+
+    public override bool IsEnabled(SlskdSettings settings) => settings.AppendYear;
+
+    public override bool CanExecute(SearchContext context, QueryType queryType)
+    {
+        if (queryType.HasFlag(QueryType.VariousArtists) ||
+            queryType.HasFlag(QueryType.SelfTitled) ||
+            queryType.HasFlag(QueryType.ShortName))
+            return false;
+
+        return context.HasValidYear &&
+               (!string.IsNullOrWhiteSpace(context.SearchArtist) ||
+                !string.IsNullOrWhiteSpace(context.SearchAlbum));
+    }
+
+    public override string? GetQuery(SearchContext context, QueryType queryType) =>
+        QueryBuilder.Build(context.SearchArtist, context.SearchAlbum, context.Year);
 }

--- a/src/Sleezer/Indexers/Soulseek/Search/Strategies/FallbackStrategy.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Strategies/FallbackStrategy.cs
@@ -3,37 +3,31 @@ using NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Transformers;
 
 namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Strategies;
 
-public sealed class WildcardStrategy : SearchStrategyBase
+public sealed class EditionStrippedStrategy : SearchStrategyBase
 {
-    public override string Name => "Trimmed Fallback";
+    public override string Name => "Edition Stripped";
     public override SearchTier Tier => SearchTier.Fallback;
     public override int Priority => 0;
 
     public override bool IsEnabled(SlskdSettings settings) => settings.UseFallbackSearch;
 
-    public override bool CanExecute(SearchContext context, QueryType queryType)
-    {
-        bool hasArtist = !string.IsNullOrWhiteSpace(context.SearchArtist) && context.SearchArtist.Length > 3;
-        bool hasAlbum = !string.IsNullOrWhiteSpace(context.SearchAlbum) && context.SearchAlbum.Length > 3;
-        return hasArtist || hasAlbum;
-    }
+    public override bool CanExecute(SearchContext context, QueryType queryType) =>
+        !context.IsSelfTitled &&
+        !string.IsNullOrWhiteSpace(context.SearchAlbum) &&
+        QueryBuilder.StripEditionSuffixes(context.SearchAlbum) != null;
 
+    // "Superstylin' (remixes)" or "OK Computer (Deluxe Edition)" — peers name
+    // folders after the plain album, so retry with the bracketed/edition tail
+    // removed. Replaces the former "Trimmed Fallback" strategy, whose
+    // last-character-stripped words ("Groov Armad Superstyli") matched nothing:
+    // Soulseek requires whole terms, verified ~100% zero-result in live logs.
     public override string? GetQuery(SearchContext context, QueryType queryType)
     {
-        string artistWildcard = QueryBuilder.BuildTrimmed(context.SearchArtist);
+        string? stripped = QueryBuilder.StripEditionSuffixes(context.SearchAlbum);
+        if (string.IsNullOrWhiteSpace(stripped))
+            return null;
 
-        if (context.IsSelfTitled)
-        {
-            if (string.IsNullOrWhiteSpace(artistWildcard))
-                return null;
-
-            return context.HasValidYear
-                ? QueryBuilder.Build(artistWildcard, context.Year)
-                : artistWildcard;
-        }
-
-        string albumWildcard = QueryBuilder.BuildTrimmed(context.SearchAlbum);
-        return QueryBuilder.Build(artistWildcard, albumWildcard);
+        return QueryBuilder.Build(context.SearchArtist, stripped);
     }
 }
 

--- a/src/Sleezer/Indexers/Soulseek/Search/Strategies/SpecialCaseStrategy.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Strategies/SpecialCaseStrategy.cs
@@ -16,10 +16,7 @@ public sealed class VariousArtistsStrategy : SearchStrategyBase
     public override string? GetQuery(SearchContext context, QueryType queryType)
     {
         if (context.HasValidYear)
-            return QueryBuilder.Build(context.SearchAlbum, context.Year, context.ReleaseTypeTag);
-
-        if (context.NeedsTypeDisambiguation)
-            return QueryBuilder.Build(context.SearchAlbum, context.ReleaseTypeTag);
+            return QueryBuilder.Build(context.SearchAlbum, context.Year);
 
         return context.SearchAlbum;
     }
@@ -39,10 +36,7 @@ public sealed class SelfTitledStrategy : SearchStrategyBase
     public override string? GetQuery(SearchContext context, QueryType queryType)
     {
         if (context.HasValidYear)
-            return QueryBuilder.Build(context.SearchArtist, context.Year, context.ReleaseTypeTag);
-
-        if (context.NeedsTypeDisambiguation)
-            return QueryBuilder.Build(context.SearchArtist, context.ReleaseTypeTag);
+            return QueryBuilder.Build(context.SearchArtist, context.Year);
 
         return context.SearchArtist;
     }
@@ -61,11 +55,11 @@ public sealed class ShortNameStrategy : SearchStrategyBase
 
     public override string? GetQuery(SearchContext context, QueryType queryType)
     {
-        // Short album names need maximum context
+        // Short album names need context, but only words peers actually put in
+        // folder names — the year qualifies, "EP"/"Single" tags do not.
         return QueryBuilder.Build(
             context.SearchArtist,
             context.SearchAlbum,
-            context.HasValidYear ? context.Year : null,
-            context.ReleaseTypeTag);
+            context.HasValidYear ? context.Year : null);
     }
 }

--- a/src/Sleezer/Indexers/Soulseek/Search/Transformers/QueryBuilder.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Transformers/QueryBuilder.cs
@@ -11,7 +11,6 @@ public static partial class QueryBuilder
         "being", "have", "has", "had", "do", "does", "did", "from", "into"
     };
 
-    private const int MinWordLengthForTrim = 4;
     private const int MinAlbumLengthForPartial = 15;
     private const int MinSignificantWordsForPartial = 2;
 
@@ -54,18 +53,24 @@ public static partial class QueryBuilder
         return text;
     }
 
-    public static string BuildTrimmed(string? text)
+    /// <summary>
+    /// Removes bracketed and dash-appended edition/remix/remaster tails from an
+    /// album title ("Album (Deluxe Edition)" → "Album"). Returns null when
+    /// nothing was stripped or nothing usable remains.
+    /// </summary>
+    public static string? StripEditionSuffixes(string? album)
     {
-        if (string.IsNullOrWhiteSpace(text))
-            return string.Empty;
+        if (string.IsNullOrWhiteSpace(album))
+            return null;
 
-        string[] words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        for (int i = 0; i < words.Length; i++)
-        {
-            if (words[i].Length >= MinWordLengthForTrim && !StopWords.Contains(words[i]))
-                words[i] = words[i][..^1];
-        }
-        return string.Join(" ", words);
+        string stripped = ParenthesesRegex().Replace(album, " ");
+        stripped = EditionTailRegex().Replace(stripped, " ");
+        stripped = System.Text.RegularExpressions.Regex.Replace(stripped, @"\s+", " ").Trim();
+
+        if (stripped.Length < 2 || stripped.Equals(album.Trim(), StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return stripped;
     }
 
     public static string? BuildPartial(string? text)
@@ -159,6 +164,11 @@ public static partial class QueryBuilder
         if (!romanMatch.Success)
             return null;
 
+        // A standalone "I" is far more often the pronoun than the numeral
+        // ("Him & I" must not become "Him & 1").
+        if (romanMatch.Groups[1].Value.Equals("I", StringComparison.OrdinalIgnoreCase))
+            return null;
+
         // Skip if part of volume reference
         Match volumeMatch = VolumeRegex().Match(album);
         if (volumeMatch.Success &&
@@ -209,6 +219,8 @@ public static partial class QueryBuilder
 
     [GeneratedRegex(@"\([^)]*\)|\[[^\]]*\]", RegexOptions.Compiled)]
     private static partial Regex ParenthesesRegex();
+    [GeneratedRegex(@"\s[-–]\s*(?:\d{4}\s+)?(?:deluxe|expanded|extended|anniversary|special|limited|collector'?s|remaster(?:ed)?|remix(?:es)?|mono|stereo|instrumental|acoustic|live)\b.*$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex EditionTailRegex();
     [GeneratedRegex(@"\b([IVXLCDM]{1,4})\b", RegexOptions.Compiled)]
     private static partial Regex StandaloneRomanRegex();
     [GeneratedRegex(@"\b(Vol(?:ume)?\.?)\s*([0-9]+|[IVXLCDM]+)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled)]

--- a/src/Sleezer/Indexers/Soulseek/Search/Transformers/QueryNormalizer.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Transformers/QueryNormalizer.cs
@@ -7,6 +7,16 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Transformers;
 
 public static partial class QueryNormalizer
 {
+    // FormD decomposition handles combining accents (é → e) but not these
+    // standalone codepoints, which appear verbatim in MusicBrainz names.
+    private static readonly Dictionary<char, string> _ligatureMap = new()
+    {
+        { 'æ', "ae" }, { 'Æ', "Ae" }, { 'œ', "oe" }, { 'Œ', "Oe" },
+        { 'ø', "o" }, { 'Ø', "O" }, { 'ð', "d" }, { 'Ð', "D" },
+        { 'þ', "th" }, { 'Þ', "Th" }, { 'ß', "ss" }, { 'đ', "d" },
+        { 'Đ', "D" }, { 'ł', "l" }, { 'Ł', "L" }, { 'ı', "i" },
+    };
+
     public static SearchContext Normalize(SearchContext context)
     {
         if (!context.QueryType.HasFlag(QueryType.NeedsNormalization))
@@ -33,12 +43,25 @@ public static partial class QueryNormalizer
         if (string.IsNullOrEmpty(input))
             return input ?? string.Empty;
 
+        // Map unicode punctuation onto its ASCII cousin BEFORE the strip pass.
+        // MusicBrainz uses typographic punctuation ("G‐Eazy" carries U+2010, not
+        // '-'); peers share plain-ASCII paths. Deleting these instead of mapping
+        // used to fuse adjacent words into tokens no peer path contains
+        // ("G‐Eazy" → "GEazy" → zero results, verified against live slskd logs).
+        string mapped = MapUnicodePunctuation(input);
+
         // Decompose accented characters (é → e + ´)
-        string decomposed = input.Normalize(NormalizationForm.FormD);
+        string decomposed = mapped.Normalize(NormalizationForm.FormD);
         StringBuilder sb = new(decomposed.Length);
 
         foreach (char c in decomposed)
         {
+            if (_ligatureMap.TryGetValue(c, out string? replacement))
+            {
+                sb.Append(replacement);
+                continue;
+            }
+
             UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(c);
             if (category != UnicodeCategory.NonSpacingMark &&
                 category != UnicodeCategory.SpacingCombiningMark &&
@@ -50,16 +73,40 @@ public static partial class QueryNormalizer
 
         string result = sb.ToString().Normalize(NormalizationForm.FormC);
 
-        // Then strip punctuation but keep letters, digits, spaces, hyphens, ampersands
+        // Apostrophes are intra-word elision: delete ("Don't" → "Dont").
+        // Every other stripped character is a separator: replace with a space
+        // so the surrounding words stay distinct search terms.
+        result = ApostropheRegex().Replace(result, "");
         result = PlusRegex().Replace(result, " ");
-        result = PunctuationRegex().Replace(result, "");
+        result = PunctuationRegex().Replace(result, " ");
         result = WhitespaceRegex().Replace(result, " ").Trim();
 
         return result;
     }
 
-    [GeneratedRegex(@"[^\w\s\-&]", RegexOptions.Compiled)]
+    private static string MapUnicodePunctuation(string input)
+    {
+        StringBuilder sb = new(input.Length);
+        foreach (char c in input)
+        {
+            sb.Append(c switch
+            {
+                '‐' or '‑' or '‒' or '–' or '—' or '―' or '−' => "-",
+                '‘' or '’' or '‚' or 'ʼ' or '`' or '´' => "'",
+                '“' or '”' or '„' => "\"",
+                '…' => " ",
+                _ => c.ToString(),
+            });
+        }
+
+        return sb.ToString();
+    }
+
+    [GeneratedRegex(@"[^\w\s\-&']", RegexOptions.Compiled)]
     private static partial Regex PunctuationRegex();
+
+    [GeneratedRegex(@"'+", RegexOptions.Compiled)]
+    private static partial Regex ApostropheRegex();
 
     [GeneratedRegex(@"\+")]
     private static partial Regex PlusRegex();

--- a/src/Sleezer/Indexers/Soulseek/SlsdkRecords.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlsdkRecords.cs
@@ -134,7 +134,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         [property: JsonPropertyName("interactive")] bool Interactive,
         [property: JsonPropertyName("expandDirectory")] bool ExpandDirectory,
         [property: JsonPropertyName("mimimumFiles")] int MinimumFiles,
-        [property: JsonPropertyName("maximumFiles")] int? MaximumFiles)
+        [property: JsonPropertyName("maximumFiles")] int? MaximumFiles,
+        [property: JsonPropertyName("trackCount")] int TrackCount = 0)
     {
         private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
         public static SlskdSearchData FromJson(string jsonString) => JsonSerializer.Deserialize<SlskdSearchData>(jsonString, _jsonOptions)!;

--- a/src/Sleezer/Indexers/Soulseek/SlskdIndexerParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdIndexerParser.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
                     IEnumerable<SlskdFileData> filteredFiles = SlskdFileData.GetFilteredFiles(response.Files, Settings.OnlyAudioFiles, Settings.IncludeFileExtensions);
 
-                    foreach (IGrouping<string, SlskdFileData> directoryGroup in filteredFiles.GroupBy(f => SlskdTextProcessor.GetDirectoryFromFilename(f.Filename)))
+                    foreach (IGrouping<string, SlskdFileData> directoryGroup in filteredFiles.GroupBy(f => SlskdTextProcessor.GetMergedDirectoryKey(f.Filename)))
                     {
                         if (string.IsNullOrEmpty(directoryGroup.Key))
                             continue;
@@ -132,7 +132,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                             }
                         }
 
-                        AlbumData albumData = _itemsParser.CreateAlbumData(searchResponse.Id, finalGroup, searchTextData, folderData, Settings, searchTextData.MinimumFiles);
+                        AlbumData albumData = _itemsParser.CreateAlbumData(searchResponse.Id, finalGroup, searchTextData, folderData, Settings, searchTextData.TrackCount);
                         albumDatas.Add(albumData);
                     }
                 }
@@ -147,7 +147,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 _logger.Error(ex, "Failed to parse Slskd search response.");
             }
 
-            return albumDatas.OrderByDescending(x => x.Priotity).Select(a => a.ToReleaseInfo()).ToList();
+            return albumDatas.OrderByDescending(x => x.Priotity).Select(a => (ReleaseInfo)a.ToShareInfo()).ToList();
         }
 
         private IGrouping<string, SlskdFileData>? TryExpandDirectory(SlskdSearchData searchTextData, IGrouping<string, SlskdFileData> directoryGroup, SlskdFolderData folderData)

--- a/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
@@ -39,7 +39,11 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         private static readonly string[] _nonArtistFolders =
         [
             "music", "mp3", "flac", "audio", "compilations", "soundtracks",
-            "pop", "rock", "jazz", "classical", "various", "downloads"
+            "pop", "rock", "jazz", "classical", "various", "downloads",
+            "shared", "share", "shares", "soulseek", "soulseek shared folder",
+            "albums", "album", "complete", "incomplete", "media", "lossless",
+            "lossy", "singles", "eps", "discography", "collection", "itunes",
+            "new music", "sorted", "unsorted"
         ];
 
         public SlskdItemsParser(Logger logger)
@@ -83,37 +87,46 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
             _logger.Trace("Creating album data - Dir: '{Dir}', Search artist: '{Artist}', Search album: '{Album}'", dirNameNorm, searchArtistNorm, searchAlbumNorm);
 
-            // Calculate fuzzy scores with caching for performance
-            (int fuzzyArtistPartial, int fuzzyArtistTokenSort) = GetCachedFuzzyScores(dirNameNorm, searchArtistNorm);
-            (int fuzzyAlbumPartial, int fuzzyAlbumTokenSort) = GetCachedFuzzyScores(dirNameNorm, searchAlbumNorm);
-
             // MatchStrictnessType values (Strict=+5, Normal=0, Loose=-5) are used directly as a threshold offset.
             int strictnessOffset = settings?.MatchStrictness ?? 0;
 
-            bool isVolumeSearch = !string.IsNullOrEmpty(searchData.Album) && VolumeRegex().Match(searchData.Album).Success;
+            // Volume-series matching only applies when the album has an explicit
+            // volume KEYWORD ("Vol. 3", "Part II"). A bare trailing number is not
+            // enough — titles that ARE numbers ("1989", "25", "IV") used to be
+            // force-routed here and could never match their own directories.
+            bool isVolumeSearch = !string.IsNullOrEmpty(searchData.Album) && VolumeKeywordRegex().Match(searchData.Album).Success;
 
-            bool isAlbumMatch = isVolumeSearch ? CheckVolumeSeriesMatch(directory.Key, searchData.Album, strictnessOffset) : !string.IsNullOrEmpty(searchAlbumNorm) && (fuzzyAlbumPartial > FuzzyAlbumPartialThreshold + strictnessOffset || fuzzyAlbumTokenSort > FuzzyAlbumTokenSortThreshold + strictnessOffset);
+            bool isAlbumMatch = isVolumeSearch
+                ? CheckVolumeSeriesMatch(directory.Key, searchData.Album, strictnessOffset)
+                : IsFuzzyAlbumNameMatch(dirNameNorm, searchAlbumNorm, strictnessOffset);
             bool isArtistMatch = IsFuzzyArtistMatch(dirNameNorm, searchArtistNorm, strictnessOffset);
+
+            bool matchedSearchCriteria = string.IsNullOrEmpty(searchAlbumNorm)
+                ? isArtistMatch
+                : isAlbumMatch && (isArtistMatch || string.IsNullOrEmpty(searchArtistNorm));
 
             if (!isArtistMatch && !isAlbumMatch && !string.IsNullOrEmpty(searchData.Artist) && !string.IsNullOrEmpty(searchData.Album))
             {
                 string combinedSearch = NormalizeString($"{searchData.Artist} {searchData.Album}");
                 (int combinedPartial, _) = GetCachedFuzzyScores(dirNameNorm, combinedSearch);
                 isAlbumMatch = combinedPartial > FuzzyCombinedThreshold + strictnessOffset;
+                matchedSearchCriteria = isAlbumMatch;
             }
 
             _logger.Debug("Match results - Artist: {ArtistMatch}, Album: {AlbumMatch}", isArtistMatch, isAlbumMatch);
 
             // Determine final values for artist, album, year
-            string finalArtist = DetermineFinalArtist(isArtistMatch, folderData, searchData);
+            string finalArtist = DetermineFinalArtist(isArtistMatch, isAlbumMatch, folderData, searchData);
             string finalAlbum = DetermineFinalAlbum(isAlbumMatch, folderData, searchData);
             string finalYear = folderData.Year;
 
             (AudioFormat Codec, int? BitRate, int? BitDepth, int? SampleRate, long TotalSize, int TotalDuration) = AnalyzeAudioQuality(directory);
             string qualityInfo = FormatQualityInfo(Codec, BitRate, BitDepth, SampleRate);
 
-            List<SlskdFileData>? filesToDownload = directory.GroupBy(f => f.Filename?[..f.Filename.LastIndexOf('\\')]).FirstOrDefault(g => g.Key == directory.Key)?.ToList();
-            int actualTrackCount = filesToDownload?.Count ?? 0;
+            // The group key is already the merged directory (disc subfolders fold
+            // into their parent), so every file in the group belongs to this release.
+            List<SlskdFileData> filesToDownload = directory.ToList();
+            int actualTrackCount = filesToDownload.Count;
 
             _logger.Trace("Audio: {Codec}, BitRate: {BitRate}, BitDepth: {BitDepth}, Files: {TrackCount}", Codec, BitRate, BitDepth, actualTrackCount);
 
@@ -137,6 +150,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 AlbumId = $"/api/v0/transfers/downloads/{folderData.Username}",
                 ArtistName = finalArtist,
                 AlbumName = finalAlbum,
+                MatchedSearchCriteria = matchedSearchCriteria,
                 ReleaseDate = finalYear,
                 ReleaseDateTime = string.IsNullOrEmpty(finalYear) || !int.TryParse(finalYear, out int yearInt)
                     ? DateTime.MinValue
@@ -172,18 +186,32 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
             string lastComponent = pathComponents[^1];
 
-            // Try artist-album-year pattern
-            Match? match = TryMatchRegex(lastComponent, ArtistAlbumYearRegex());
-            if (match != null)
+            // Year-led folders ("1969 - Artist - Album", "(2002) Album",
+            // "1994 - Album") must be tried before the artist-album split, or the
+            // year gets mistaken for the artist.
+            if (LeadingYearProbeRegex().IsMatch(lastComponent))
             {
-                return (
-                    match.Groups["artist"].Success ? match.Groups["artist"].Value.Trim() : null,
-                    match.Groups["album"].Success ? match.Groups["album"].Value.Trim() : null,
-                    match.Groups["year"].Success ? match.Groups["year"].Value.Trim() : null);
+                Match? yearMatch = TryMatchRegex(lastComponent, YearArtistAlbumRegex());
+                if (yearMatch != null)
+                {
+                    return (
+                        yearMatch.Groups["artist"].Success ? yearMatch.Groups["artist"].Value.Trim() : null,
+                        yearMatch.Groups["album"].Success ? yearMatch.Groups["album"].Value.Trim() : null,
+                        yearMatch.Groups["year"].Success ? yearMatch.Groups["year"].Value.Trim() : null);
+                }
+
+                yearMatch = TryMatchRegex(lastComponent, LeadingYearAlbumRegex());
+                if (yearMatch?.Groups["album"].Success == true)
+                {
+                    return (
+                        GetArtistFromParentFolder(pathComponents),
+                        yearMatch.Groups["album"].Value.Trim(),
+                        yearMatch.Groups["year"].Success ? yearMatch.Groups["year"].Value.Trim() : null);
+                }
             }
 
-            // Try year-artist-album pattern
-            match = TryMatchRegex(lastComponent, YearArtistAlbumRegex());
+            // Try artist-album-year pattern
+            Match? match = TryMatchRegex(lastComponent, ArtistAlbumYearRegex());
             if (match != null)
             {
                 return (
@@ -211,11 +239,18 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         private static string? GetArtistFromParentFolder(string[] pathComponents)
         {
             if (pathComponents.Length < 2) return null;
-            string parentFolder = pathComponents[^2];
-            if (!_nonArtistFolders.Contains(parentFolder.ToLowerInvariant()))
-                return parentFolder;
+            string parentFolder = pathComponents[^2].Trim();
 
-            return null;
+            // Share roots ("@@abc123"), drive letters and generic library folders
+            // are not artist names; better to leave the artist unknown than to
+            // fabricate one Lidarr can never match.
+            if (parentFolder.StartsWith('@') ||
+                parentFolder.Length <= 1 ||
+                ShareRootRegex().IsMatch(parentFolder) ||
+                _nonArtistFolders.Contains(parentFolder.ToLowerInvariant()))
+                return null;
+
+            return parentFolder;
         }
 
         private bool CheckVolumeSeriesMatch(string directoryPath, string? searchAlbum, int strictnessOffset = 0)
@@ -312,11 +347,22 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         {
             if (string.IsNullOrEmpty(input))
                 return string.Empty;
+
+            // Separators (incl. backslash — the full slskd path is normalized
+            // here, and deleting the separator used to glue adjacent path
+            // components into unmatchable tokens) and punctuation become spaces,
+            // never plain deletions, so word tokens survive on both sides of the
+            // fuzzy comparison.
             string normalized = NormalizeCharactersRegex().Replace(input, " ");
-            normalized = RemoveNonAlphanumericRegex().Replace(normalized, "");
+            normalized = RemoveNonAlphanumericRegex().Replace(normalized, " ");
             normalized = ReduceWhitespaceRegex().Replace(normalized.ToLowerInvariant(), " ").Trim();
-            normalized = RemoveWordsRegex().Replace(normalized, "");
-            return ReduceWhitespaceRegex().Replace(normalized, " ").Trim();
+
+            string withoutStopWords = RemoveWordsRegex().Replace(normalized, "");
+            withoutStopWords = ReduceWhitespaceRegex().Replace(withoutStopWords, " ").Trim();
+
+            // Names made entirely of stop words ("The The") must not normalize
+            // to empty — an empty operand can never fuzzy-match anything.
+            return withoutStopWords.Length > 0 ? withoutStopWords : normalized;
         }
 
         private static string CleanComponent(string component)
@@ -362,20 +408,31 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             return match.Success ? match : null;
         }
 
+        // Below this normalized length, PartialRatio saturates at ~100 against
+        // almost any long path ("low" matches "follow", "19" matches "2019"), so
+        // short names require an exact word-token hit instead of a fuzzy score.
+        private const int ShortNameTokenLength = 4;
+
+        private static bool ContainsWordToken(string dirNameNorm, string queryNorm) =>
+            dirNameNorm.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Contains(queryNorm, StringComparer.Ordinal);
+
         private static bool IsFuzzyArtistMatch(string dirNameNorm, string searchArtistNorm, int strictnessOffset = 0)
         {
             if (string.IsNullOrEmpty(searchArtistNorm))
                 return false;
+            if (searchArtistNorm.Length <= ShortNameTokenLength)
+                return ContainsWordToken(dirNameNorm, searchArtistNorm);
             (int partial, int tokenSort) = GetCachedFuzzyScores(dirNameNorm, searchArtistNorm);
             return partial > FuzzyArtistPartialThreshold + strictnessOffset || tokenSort > FuzzyArtistTokenSortThreshold + strictnessOffset;
         }
 
-        private static bool IsFuzzyAlbumMatch(string dirNameNorm, string searchAlbumNorm, bool volumeMatch, int strictnessOffset = 0)
+        private static bool IsFuzzyAlbumNameMatch(string dirNameNorm, string searchAlbumNorm, int strictnessOffset = 0)
         {
             if (string.IsNullOrEmpty(searchAlbumNorm))
                 return false;
-            if (volumeMatch)
-                return true;
+            if (searchAlbumNorm.Length <= ShortNameTokenLength)
+                return ContainsWordToken(dirNameNorm, searchAlbumNorm);
             (int partial, int tokenSort) = GetCachedFuzzyScores(dirNameNorm, searchAlbumNorm);
             return partial > FuzzyAlbumPartialThreshold + strictnessOffset || tokenSort > FuzzyAlbumTokenSortThreshold + strictnessOffset;
         }
@@ -408,30 +465,18 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             });
         }
 
-        public static string DetermineRegexMatchType(string folderPath)
-        {
-            string[] pathComponents = SplitPathIntoComponents(folderPath);
-            if (pathComponents.Length == 0)
-                return "none";
-
-            string lastComponent = pathComponents[^1];
-
-            if (TryMatchRegex(lastComponent, ArtistAlbumYearRegex()) != null)
-                return "ArtistAlbumYear";
-
-            if (TryMatchRegex(lastComponent, YearArtistAlbumRegex()) != null)
-                return "YearArtistAlbum";
-
-            if (TryMatchRegex(lastComponent, AlbumYearRegex()) != null)
-                return "AlbumYear";
-
-            return "none";
-        }
-
-        private static string DetermineFinalArtist(bool isArtistMatch, SlskdFolderData folderData, SlskdSearchData searchData)
+        private static string DetermineFinalArtist(bool isArtistMatch, bool isAlbumMatch, SlskdFolderData folderData, SlskdSearchData searchData)
         {
             if (isArtistMatch && !string.IsNullOrEmpty(searchData.Artist))
                 return searchData.Artist;
+
+            // Album matched but the artist name isn't in the path (flat share
+            // layouts, "@@share" roots): trust the album evidence and stamp the
+            // searched artist — a folder-derived "@@abc123" artist would make
+            // Lidarr reject an otherwise-correct release.
+            if (isAlbumMatch && !string.IsNullOrEmpty(searchData.Artist))
+                return searchData.Artist;
+
             if (!string.IsNullOrEmpty(folderData.Artist))
                 return folderData.Artist;
             return searchData.Artist ?? "Unknown Artist";
@@ -441,8 +486,11 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         {
             if (isAlbumMatch && !string.IsNullOrEmpty(searchData.Album))
             {
-                Match folderVersion = VolumeRegex().Match(folderData.Album ?? "");
-                Match searchVersion = VolumeRegex().Match(searchData.Album);
+                // Carry an explicit keyworded volume marker ("Vol. 3") over from
+                // the folder; a bare trailing number ("...CD 1", "1989") must not
+                // be appended to the searched title.
+                Match folderVersion = VolumeKeywordRegex().Match(folderData.Album ?? "");
+                Match searchVersion = VolumeKeywordRegex().Match(searchData.Album);
                 return folderVersion.Success && !searchVersion.Success ? $"{searchData.Album} {folderVersion.Value}" : searchData.Album;
             }
             if (!string.IsNullOrEmpty(folderData.Album))
@@ -523,11 +571,27 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         [GeneratedRegex(@"^(?<album>[^(\[]+)(?:\s*[\(\[](?<year>19\d{2}|20\d{2})[\)\]])?", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex AlbumYearRegex();
 
-        [GeneratedRegex(@"^(?<year>19\d{2}|20\d{2})\s*-\s*(?<artist>[^-]+)\s*-\s*(?<album>.+)(?:\s*[\(\[].+[\)\]])*$", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        // Artist/album splits require " - " (space-hyphen-space): hyphenated
+        // names ("Jay-Z", "AC-DC") must not be cut at their internal hyphen.
+        [GeneratedRegex(@"^(?<year>19\d{2}|20\d{2})\s*-\s*(?<artist>.+?)\s-\s(?<album>.+)$", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex YearArtistAlbumRegex();
 
-        [GeneratedRegex(@"^(?<artist>[^-]+)\s*-\s*(?<album>[^(\[]+)(?:\s*[\(\[](?<year>19\d{2}|20\d{2})[\)\]])?", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        [GeneratedRegex(@"^[\(\[]?(?<year>19\d{2}|20\d{2})[\)\]]?\s*(?:-\s*)?(?<album>.+)$", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        private static partial Regex LeadingYearAlbumRegex();
+
+        [GeneratedRegex(@"^[\(\[]?(?:19|20)\d{2}\b", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        private static partial Regex LeadingYearProbeRegex();
+
+        [GeneratedRegex(@"^(?<artist>.+?)\s-\s(?<album>[^(\[]+)(?:\s*[\(\[](?<year>19\d{2}|20\d{2})[\)\]])?", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex ArtistAlbumYearRegex();
+
+        [GeneratedRegex(@"^[a-zA-Z]:?$|^(?:vol(?:ume)?|cd|disc|disk)\s*\d*$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        private static partial Regex ShareRootRegex();
+
+        [GeneratedRegex(@"(?ix)
+            (?<=\b(?:volume|vol|part|pt|chapter|sampler|ed|ver|release|issue|series|no|num|phase|stage|book|side|disc|cd|dvd|season|installment|\#)\s*[.,\-_:#]*\s*)
+            (\d+(?:\.\d+)?|[IVXLCDM]+|\d+(?:[-to&]\d+)?|one|two|three|four|five|six|seven|eight|nine|ten)(?!\w)", RegexOptions.ExplicitCapture | RegexOptions.Compiled, "de-DE")]
+        private static partial Regex VolumeKeywordRegex();
 
         [GeneratedRegex(@"(?<year>19\d{2}|20\d{2})", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex YearExtractionRegex();
@@ -550,10 +614,10 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         [GeneratedRegex(@"\s+", RegexOptions.Compiled)]
         private static partial Regex ReduceWhitespaceRegex();
 
-        [GeneratedRegex(@"[^\w\s$-]", RegexOptions.Compiled)]
+        [GeneratedRegex(@"[^\w\s$]", RegexOptions.Compiled)]
         private static partial Regex RemoveNonAlphanumericRegex();
 
-        [GeneratedRegex(@"[._/]+", RegexOptions.Compiled)]
+        [GeneratedRegex(@"[-._/\\]+", RegexOptions.Compiled)]
         private static partial Regex NormalizeCharactersRegex();
     }
 }

--- a/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -59,11 +59,16 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
             _processedSearches.Clear();
 
+            // Album entity title, NOT searchCriteria.AlbumQuery — AlbumQuery is
+            // "{Title}+{Disambiguation}" and the fused "+..." token poisons the
+            // Soulseek query (every term is mandatory). Self-titled albums keep
+            // their title here too: the pipeline's SelfTitled handling dedupes
+            // the query text, while the parser still needs the album name to
+            // stamp matched directories.
             SearchContext context = new(
                 Artist: searchCriteria.ArtistQuery,
-                Album: searchCriteria.ArtistQuery != searchCriteria.AlbumQuery ? searchCriteria.AlbumQuery : null,
+                Album: album?.Title ?? searchCriteria.AlbumQuery,
                 Year: searchCriteria.AlbumYear.ToString(),
-                PrimaryType: GetPrimaryAlbumType(album?.AlbumType),
                 Interactive: searchCriteria.InteractiveSearch,
                 TrackCount: trackCount,
                 Aliases: searchCriteria.Artist?.Metadata.Value.Aliases ?? [],
@@ -89,11 +94,12 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
             _processedSearches.Clear();
 
+            // Raw artist name — CleanArtistQuery is "+"-joined ("Pink+Floyd"),
+            // which no peer path contains.
             SearchContext context = new(
-                Artist: searchCriteria.CleanArtistQuery,
+                Artist: searchCriteria.ArtistQuery,
                 Album: null,
                 Year: null,
-                PrimaryType: GetPrimaryAlbumType(album?.AlbumType),
                 Interactive: searchCriteria.InteractiveSearch,
                 TrackCount: trackCount,
                 Aliases: searchCriteria.Artist?.Metadata.Value.Aliases ?? [],
@@ -163,22 +169,19 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 _logger.Warn(ex, "Search request failed for: {SearchText}", searchText);
                 return null;
             }
-            catch (SearchGateTimeoutException)
+            catch (RequestLimitReachedException)
             {
-                // Already logged at Warn inside ExecuteSearchAsync. Skip this one so Lidarr re-queues
-                // the album later instead of holding a search-task slot for the full timeout.
-                return null;
+                // Gate timeout / persistent 429. Propagate so Lidarr records a
+                // FAILURE with a short backoff instead of a clean "searched,
+                // nothing found" — swallowing it here made a transient slskd
+                // hiccup indistinguishable from "album does not exist".
+                throw;
             }
             catch (Exception ex)
             {
                 _logger.Error(ex, "Error generating search request for: {SearchText}", searchText);
                 return null;
             }
-        }
-
-        private sealed class SearchGateTimeoutException : Exception
-        {
-            public SearchGateTimeoutException(string message) : base(message) { }
         }
 
         private dynamic CreateSearchData(string searchText) => new
@@ -223,9 +226,11 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             Stopwatch waitSw = Stopwatch.StartNew();
             if (!await gate.WaitAsync(acquireCap))
             {
-                _logger.Warn("Slskd search gate timeout for {BaseUrl} after {ElapsedMs}ms; skipping search {SearchId} (Lidarr will retry the album)",
+                _logger.Warn("Slskd search gate timeout for {BaseUrl} after {ElapsedMs}ms; failing search {SearchId} so Lidarr backs off and retries",
                     Settings.BaseUrl, waitSw.ElapsedMilliseconds, searchId);
-                throw new SearchGateTimeoutException($"Could not acquire slskd search gate within {acquireCap.TotalSeconds:F0}s");
+                throw new RequestLimitReachedException(
+                    $"Could not acquire slskd search gate within {acquireCap.TotalSeconds:F0}s — slskd is busy.",
+                    TimeSpan.FromMinutes(2));
             }
 
             if (contended)
@@ -244,7 +249,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         // Even with the gate held, a third party may be hitting the same slskd (e.g. the user has the slskd
         // web UI open and started a manual search). Treat 429 as a transient and retry once after a short
-        // backoff before giving up.
+        // backoff; if it persists, fail the search with a short indexer backoff instead of returning an
+        // empty result Lidarr would record as "searched, nothing found".
         private async Task ExecuteCreateSearchWithRetryAsync(HttpRequest searchRequest, string searchId)
         {
             try
@@ -258,7 +264,16 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             }
 
             await Task.Delay(TimeSpan.FromSeconds(2));
-            await _client.ExecuteAsync(searchRequest);
+            try
+            {
+                await _client.ExecuteAsync(searchRequest);
+            }
+            catch (HttpException ex) when ((int)ex.Response.StatusCode == 429)
+            {
+                throw new RequestLimitReachedException(
+                    "slskd keeps returning 429 for new searches — another client is using it. Backing off.",
+                    TimeSpan.FromMinutes(5));
+            }
         }
 
         private HttpRequest CreateResultRequest(string searchId, SearchQuery query)
@@ -291,7 +306,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 Interactive = query.Interactive,
                 ExpandDirectory = query.ExpandDirectory,
                 MimimumFiles = minimumFiles,
-                MaximumFiles = maximumFiles
+                MaximumFiles = maximumFiles,
+                TrackCount = query.TrackCount
             }.ToJson();
 
             return request;
@@ -361,17 +377,6 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
             double delay = (a * Math.Pow(progress, 2)) + (b * progress) + c;
             return Math.Clamp(delay, 0.5, 5);
-        }
-
-        private static PrimaryAlbumType GetPrimaryAlbumType(string? albumType)
-        {
-            if (string.IsNullOrWhiteSpace(albumType))
-                return PrimaryAlbumType.Album;
-
-            PrimaryAlbumType? matchedType = PrimaryAlbumType.All
-                .FirstOrDefault(t => t.Name.Equals(albumType, StringComparison.OrdinalIgnoreCase));
-
-            return matchedType ?? PrimaryAlbumType.Album;
         }
 
         public async Task<IGrouping<string, SlskdFileData>?> ExpandDirectory(string username, string directoryPath, SlskdFileData originalTrack)

--- a/src/Sleezer/Indexers/Soulseek/SlskdSettings.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdSettings.cs
@@ -52,10 +52,11 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 .GreaterThanOrEqualTo(1)
                 .WithMessage("Response Limit must be at least 1.");
 
-            // Timeout validation
+            // Timeout validation. Floor of 5s: this value is slskd's server-side
+            // Soulseek search window, and below ~5s most peers never answer.
             RuleFor(c => c.TimeoutInSeconds)
-                .GreaterThanOrEqualTo(2.0)
-                .WithMessage("Timeout must be at least 2 seconds.");
+                .GreaterThanOrEqualTo(5.0)
+                .WithMessage("Timeout must be at least 5 seconds — this is how long slskd collects responses from Soulseek peers.");
 
             // TrackFallback validation
             RuleFor(c => c.UseTrackFallback)
@@ -144,16 +145,16 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         public int TrackCountFilter { get; set; } = (int)TrackCountFilterType.Disabled;
 
         [FieldDefinition(12, Type = FieldType.Number, Label = "Response Limit", HelpText = "Max search responses", Advanced = true)]
-        public int ResponseLimit { get; set; } = 100;
+        public int ResponseLimit { get; set; } = 200;
 
-        [FieldDefinition(13, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Search timeout", Advanced = true)]
-        public double TimeoutInSeconds { get; set; } = 5;
+        [FieldDefinition(13, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "How long slskd searches the Soulseek network. Soulseek peers commonly answer after 5-20s, so low values silently drop most results.", Advanced = true)]
+        public double TimeoutInSeconds { get; set; } = 15;
 
-        [FieldDefinition(14, Type = FieldType.Checkbox, Label = "Append Year", HelpText = "Append the release year to the first search (ignored when templates are set)", Advanced = true)]
+        [FieldDefinition(14, Type = FieldType.Checkbox, Label = "Append Year", HelpText = "Also try a year-tagged search variant after the plain artist+album query (ignored when templates are set)", Advanced = true)]
         public bool AppendYear { get; set; }
 
         [FieldDefinition(15, Type = FieldType.Checkbox, Label = "Normalize Search", HelpText = "Remove accents and special characters (é→e, ü→u)", Advanced = true)]
-        public bool NormalizedSeach { get; set; }
+        public bool NormalizedSeach { get; set; } = true;
 
         [FieldDefinition(16, Type = FieldType.Checkbox, Label = "Volume Variations", HelpText = "Try alternate volume formats (Vol.1 <-> Volume I)", Advanced = true)]
         public bool HandleVolumeVariations { get; set; }

--- a/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
@@ -129,12 +129,37 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 yield return album.Replace(romanMatch.Value, arabicNumber.ToString());
         }
 
+        private static readonly char[] PathSeparators = ['\\', '/'];
+
+        // Soulseek paths are canonically backslash-separated, but some clients
+        // (Nicotine+ on POSIX) leak forward slashes into shared paths.
         public static string GetDirectoryFromFilename(string? filename)
         {
             if (string.IsNullOrEmpty(filename))
                 return "";
-            int lastBackslashIndex = filename.LastIndexOf('\\');
-            return lastBackslashIndex >= 0 ? filename[..lastBackslashIndex] : "";
+            int lastSeparatorIndex = filename.LastIndexOfAny(PathSeparators);
+            return lastSeparatorIndex >= 0 ? filename[..lastSeparatorIndex] : "";
+        }
+
+        public static bool IsDiscFolderName(string? name) =>
+            !string.IsNullOrWhiteSpace(name) && DiscFolderRegex().IsMatch(name.Trim());
+
+        /// <summary>
+        /// Directory key for grouping search-result files into releases. Files
+        /// inside a disc subfolder (Album\CD1, Album\Disc 2) group under the
+        /// parent album folder, so multi-disc shares surface as one release
+        /// instead of per-disc fragments that fail track-count filtering.
+        /// </summary>
+        public static string GetMergedDirectoryKey(string? filename)
+        {
+            string directory = GetDirectoryFromFilename(filename);
+            int lastSeparatorIndex = directory.LastIndexOfAny(PathSeparators);
+            if (lastSeparatorIndex < 0)
+                return directory;
+
+            return IsDiscFolderName(directory[(lastSeparatorIndex + 1)..])
+                ? directory[..lastSeparatorIndex]
+                : directory;
         }
 
         public static HashSet<string> ParseListContent(string content)
@@ -151,5 +176,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         [GeneratedRegex(@"\s+")]
         private static partial Regex StripPunctuationRegex();
+
+        [GeneratedRegex(@"^(?:cd|disc|disk|dvd)\s*[-_. ]?\s*\d{1,2}$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        private static partial Regex DiscFolderRegex();
     }
 }

--- a/tests/Sleezer.Tests/Sleezer.Tests.csproj
+++ b/tests/Sleezer.Tests/Sleezer.Tests.csproj
@@ -20,6 +20,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <!-- Same version as Sleezer.csproj — SlskdItemsParser fuzzy matching. -->
+    <PackageReference Include="FuzzySharp" Version="2.0.2" />
+    <!-- NzbDroneLogger's static initializer needs this at runtime (same version
+         as Lidarr.Common); without it any type that logs via NzbDroneLogger
+         throws TypeInitializationException under the test host. -->
+    <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -55,6 +61,33 @@
     <Compile Include="..\..\src\Sleezer\TidalSharp\LosslessGuard.cs"
              LinkBase="SourceUnderTest" />
     <Compile Include="..\..\src\Sleezer\TidalSharp\Data\Quality.cs"
+             LinkBase="SourceUnderTest" />
+    <!-- Slskd search/matching units (2026-07 audit fixes) and their deps. -->
+    <Compile Include="..\..\src\Sleezer\Indexers\DownloadProtocols.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\SlskdTextProcessor.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\SlskdItemsParser.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\ISlskdItemsParser.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\SlskdSettings.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\Search\Core\SearchContext.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\Search\Templates\TemplateEngine.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\Search\Transformers\QueryNormalizer.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Indexers\Soulseek\Search\Transformers\QueryBuilder.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Core\Model\AlbumData.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Core\Model\ShareInfo.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Download\Clients\Soulseek\Models\SlskdDownloadItem.cs"
+             LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Download\Clients\Soulseek\Models\SlskdDownloadDirectory.cs"
              LinkBase="SourceUnderTest" />
   </ItemGroup>
 

--- a/tests/Sleezer.Tests/SlskdSearchMatchingTests.cs
+++ b/tests/Sleezer.Tests/SlskdSearchMatchingTests.cs
@@ -1,0 +1,179 @@
+using NLog;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Plugin.Sleezer.Core.Model;
+using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Transformers;
+using Xunit;
+
+namespace Sleezer.Tests;
+
+// Covers the slskd search/matching fixes from the 2026-07 audit: query
+// normalization that used to fuse words ("G‐Eazy" → "GEazy" → zero results),
+// disc-subfolder grouping, folder-name parsing splits, and multi-disc
+// download-item path handling.
+public class QueryNormalizerTests
+{
+    [Theory]
+    [InlineData("G‐Eazy", "G-Eazy")]                    // U+2010 HYPHEN (MusicBrainz) → ASCII, not deleted
+    [InlineData("Sigur Rós", "Sigur Ros")]
+    [InlineData("Ágætis byrjun", "Agaetis byrjun")] // ligature æ folds to ae
+    [InlineData("Don't", "Dont")]                             // apostrophes are elision, not separators
+    [InlineData("Superstylin’", "Superstylin")]
+    [InlineData("AC/DC", "AC DC")]
+    [InlineData("Weezer+Blue Album", "Weezer Blue Album")]
+    [InlineData("Him & I", "Him & I")]
+    public void NormalizeText_produces_peer_matchable_terms(string input, string expected)
+    {
+        Assert.Equal(expected, QueryNormalizer.NormalizeText(input));
+    }
+}
+
+public class QueryBuilderTests
+{
+    [Fact]
+    public void ConvertRomanNumeral_does_not_convert_the_pronoun_I()
+    {
+        Assert.Null(QueryBuilder.ConvertRomanNumeral("Him & I"));
+    }
+
+    [Fact]
+    public void ConvertRomanNumeral_still_converts_real_numerals()
+    {
+        Assert.Equal("Led Zeppelin 4", QueryBuilder.ConvertRomanNumeral("Led Zeppelin IV"));
+    }
+
+    [Theory]
+    [InlineData("Superstylin (remixes)", "Superstylin")]
+    [InlineData("OK Computer (Deluxe Edition)", "OK Computer")]
+    [InlineData("Lateralus", null)]                           // nothing to strip
+    public void StripEditionSuffixes_removes_bracketed_tails(string input, string? expected)
+    {
+        Assert.Equal(expected, QueryBuilder.StripEditionSuffixes(input));
+    }
+}
+
+public class SlskdTextProcessorTests
+{
+    [Theory]
+    [InlineData(@"@@x\Artist\Album\CD1\01.flac", @"@@x\Artist\Album")]
+    [InlineData(@"@@x\Artist\Album\Disc 2\01.flac", @"@@x\Artist\Album")]
+    [InlineData(@"@@x\Artist\Album\01.flac", @"@@x\Artist\Album")]
+    [InlineData(@"@@x\Artist\CD Collection\01.flac", @"@@x\Artist\CD Collection")] // not a disc leaf
+    public void GetMergedDirectoryKey_folds_disc_subfolders(string filename, string expected)
+    {
+        Assert.Equal(expected, SlskdTextProcessor.GetMergedDirectoryKey(filename));
+    }
+
+    [Fact]
+    public void GetDirectoryFromFilename_handles_posix_separators()
+    {
+        Assert.Equal("music/Artist/Album", SlskdTextProcessor.GetDirectoryFromFilename("music/Artist/Album/01.flac"));
+    }
+}
+
+public class SlskdItemsParserTests
+{
+    private static readonly SlskdItemsParser Parser = new(LogManager.GetCurrentClassLogger());
+
+    [Fact]
+    public void NormalizeString_treats_backslash_as_separator()
+    {
+        string normalized = SlskdItemsParser.NormalizeString(@"@@va15b\Music\Taylor Swift\1989 (2014) [FLAC]");
+        Assert.Contains("taylor swift 1989", normalized);
+    }
+
+    [Fact]
+    public void NormalizeString_never_returns_empty_for_stopword_names()
+    {
+        Assert.Equal("the the", SlskdItemsParser.NormalizeString("The The"));
+    }
+
+    [Fact]
+    public void ParseFolderName_keeps_hyphenated_artist_names_intact()
+    {
+        SlskdFolderData data = Parser.ParseFolderName(@"@@u\Jay-Z - The Blueprint (2001)");
+        Assert.Equal("Jay-Z", data.Artist);
+        Assert.Equal("The Blueprint", data.Album);
+        Assert.Equal("2001", data.Year);
+    }
+
+    [Fact]
+    public void ParseFolderName_parses_year_led_discography_folders()
+    {
+        SlskdFolderData data = Parser.ParseFolderName(@"@@u\Nirvana\1993 - In Utero");
+        Assert.Equal("Nirvana", data.Artist);
+        Assert.Equal("In Utero", data.Album);
+        Assert.Equal("1993", data.Year);
+    }
+
+    [Fact]
+    public void ParseFolderName_parses_year_artist_album_folders()
+    {
+        SlskdFolderData data = Parser.ParseFolderName(@"@@u\1969 - The Stooges - The Stooges");
+        Assert.Equal("The Stooges", data.Artist);
+        Assert.Equal("The Stooges", data.Album);
+        Assert.Equal("1969", data.Year);
+    }
+
+    [Fact]
+    public void ParseFolderName_rejects_share_roots_as_artist()
+    {
+        SlskdFolderData data = Parser.ParseFolderName(@"@@abc123\Nevermind (1991)");
+        Assert.NotEqual("@@abc123", data.Artist);
+    }
+}
+
+public class SlskdDownloadItemMultiDiscTests
+{
+    private static SlskdDownloadItem NewItem(params string[] filenames)
+    {
+        string source = "[" + string.Join(",", filenames.Select(f =>
+            $"{{\"Filename\":{System.Text.Json.JsonSerializer.Serialize(f)},\"Size\":1000}}")) + "]";
+        return new SlskdDownloadItem(new ReleaseInfo { Source = source, Title = "t", DownloadUrl = "u" });
+    }
+
+    [Fact]
+    public void Single_directory_items_are_not_multi_directory()
+    {
+        SlskdDownloadItem item = NewItem(@"@@x\Artist\Album\01.flac", @"@@x\Artist\Album\02.flac");
+        Assert.False(item.IsMultiDirectory);
+    }
+
+    [Fact]
+    public void Disc_subfolders_make_a_multi_directory_item_with_album_output_folder()
+    {
+        SlskdDownloadItem item = NewItem(@"@@x\Artist\Album\CD1\01.flac", @"@@x\Artist\Album\CD2\01.flac");
+        Assert.True(item.IsMultiDirectory);
+        Assert.Equal("Album", item.LocalAlbumFolderName());
+        Assert.Equal(new HashSet<string> { "CD1", "CD2" }, new HashSet<string>(item.RemoteDirectoryLeaves()));
+    }
+
+    [Fact]
+    public void Ownership_lookup_matches_enqueued_files()
+    {
+        SlskdDownloadItem item = NewItem(@"@@x\Artist\Album\CD1\01.flac", @"@@x\Artist\Album\CD2\01.flac");
+        Assert.True(item.OwnsFile(@"@@x\Artist\Album\CD2\01.flac"));
+        Assert.False(item.OwnsFile(@"@@x\Artist\Other\01.flac"));
+    }
+}
+
+public class ShareInfoTests
+{
+    [Fact]
+    public void ToShareInfo_carries_priority_as_seeders_and_match_flag()
+    {
+        AlbumData albumData = new("Slskd", "SoulseekDownloadProtocol")
+        {
+            ArtistName = "Artist",
+            AlbumName = "Album",
+            AlbumId = "/api/v0/transfers/downloads/user",
+            Priotity = 4321,
+            MatchedSearchCriteria = true,
+        };
+
+        ShareInfo release = albumData.ToShareInfo();
+        Assert.Equal(4321, release.Seeders);
+        Assert.True(release.MatchedSearchCriteria);
+    }
+}


### PR DESCRIPTION
## Why

A week of live Lidarr + slskd logs showed **44% of 1,133 searches returning zero responses**, and a code audit of the slskd search→parse→match flow traced both user-visible symptoms — albums not found despite existing on Soulseek, and occasional wrong-album grabs — to concrete defects. Highlights from the live evidence:

- MusicBrainz spells "G‐Eazy" with U+2010; the normalizer deleted it, producing the fused token `GEazy` — **55/55 queries, all zero results**.
- The first query carried year + release-type words (`Groove Armada Superstylin 2006 Single` → 0), and the plain `Artist Album` query often **never ran** because a junk variant tier satisfied the stop threshold first.
- The "trimmed" fallback (`Groov Armad Superstyli`, `Snoo Dog Liv From the Mothershi II Emergenc Landin`) was ~100% zero-result: Soulseek matches whole terms.
- Multi-disc shares split into per-disc groups that individually failed track-count filtering.
- `SlskdIndexer.CleanupReleases` was dead code — releases were plain `ReleaseInfo`, so the computed share priority never reached Lidarr's decision engine and candidates ranked on quality alone.

## What

**Query generation**
- Unicode punctuation maps to ASCII before stripping; separators become spaces instead of deletions; ligatures (æ ø ß þ …) fold. `G‐Eazy` → `G-Eazy`.
- Plain `Artist Album` is the first query. Year moves to its own tier behind *Append Year*; EP/Single words are gone.
- Album title comes from the album entity (not `AlbumQuery`'s `Title+Disambiguation`), artist search uses the raw name (not `Pink+Floyd`-style `CleanArtistQuery`), and self-titled albums keep their album name so the parser can stamp matched directories.
- Trimmed-words fallback replaced by an edition/remix-suffix-stripped fallback; bare "I" is no longer converted to "1" (`Him & I`).

**Matching / parsing**
- `CD1`/`Disc N` subfolders group under their parent album (merged directory key) so multi-disc shares are one release.
- Volume-series matching requires an explicit volume keyword — number titles (*1989*, *25*, *IV*) fuzzy-match normally again.
- Backslashes are separators during normalization (no more glued path components); normalization can't empty a name (*The The*); names ≤4 chars need an exact word token instead of a saturated PartialRatio.
- Year-led folder patterns (`1969 - Artist - Album`, `(2002) Album`, `1994 - Album`) parse before the artist split; artist splits require ` - ` so *Jay-Z* survives; share roots (`@@abc`, drive letters, library folders) are rejected as artist names.
- When the album matches but the artist isn't in the path, the searched artist is stamped so Lidarr can match flat share layouts.

**Ranking / tier flow**
- New `ShareInfo : TorrentInfo` release type carries the share score as `Seeders`, reactivating `CleanupReleases` → `IndexerPriority`. `CalculatePriority` now receives the real album track count instead of the filter floor.
- Tier stop decisions count only releases that matched the search criteria — bystander folders can't starve recovery tiers.
- Search-gate timeouts / persistent 429s fail the search with a short indexer backoff instead of recording a clean "nothing found".

**Download client (multi-disc end-to-end)**
- Per-directory slskd transfers map back to their item by enqueued-file membership (the per-directory hash never matched a multi-disc item's ID); completion waits for every enqueued file.
- After completion, per-disc local folders merge into one album folder (all moves re-checked against the download root) and `OutputPath` points at it, so Lidarr imports the whole album. Unmerged disc folders are cleaned up on removal.

**Defaults**: search timeout 5s → 15s (this is slskd's server-side Soulseek collection window; peers commonly answer after 5–20s), validation floor 2s → 5s, response limit 100 → 200, Normalize Search on for new installs.

## Testing

- `dotnet build Sleezer.sln -c Release -p:NuGetAudit=false` — clean, 0 warnings.
- `dotnet test tests/Sleezer.Tests` — 163 passed (new coverage: normalizer term fidelity, disc-key merging, folder-name parsing splits, multi-disc item paths, ShareInfo priority plumbing; test csproj gained the units under test + FuzzySharp/ClefJsonLayout).

## Known limitation

In-flight **multi-disc** downloads don't reattach after a Lidarr restart (a per-directory transfer hash can't reconstruct the full-release ID); Lidarr re-grabs on the next search. Single-directory downloads reattach as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-disc Soulseek transfers are now supported across multiple folders with automatic merging into a single album destination.
  * Enhanced query building (including optional year follow-ups) and improved handling of edition/variant suffixes and volume labels.
* **Bug Fixes**
  * Release search now filters by matched criteria to avoid stopping early on non-matching results.
  * Improved folder parsing and matching accuracy across diverse naming layouts.
* **Settings**
  * Increased default Soulseek response limit and timeout; normalized searching enabled by default.
* **Tests**
  * Added comprehensive coverage for search matching, query normalization/building, folder parsing, and multi-disc behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->