### PR TITLE
feat(slskd): port upstream Tubifarry fixes (blocked terms, batch API, evidence matching)

### DIFF
--- a/src/Sleezer/Core/Model/AlbumData.cs
+++ b/src/Sleezer/Core/Model/AlbumData.cs
@@ -39,6 +39,10 @@ namespace NzbDrone.Plugin.Sleezer.Core.Model
 
         public int Priotity { get; set; }
         public bool MatchedSearchCriteria { get; set; }
+
+        // Detected media source ("WEB", "CD", "Vinyl", "SACD") — parsed by
+        // Lidarr's quality detection from the title suffix.
+        public string SourceTag { get; set; } = "WEB";
         public List<string>? ExtraInfo { get; set; }
 
         public string DownloadProtocol { get; set; } = downloadProtocol;
@@ -124,7 +128,7 @@ namespace NzbDrone.Plugin.Sleezer.Core.Model
             if (ExtraInfo?.Count > 0)
                 title += string.Concat(ExtraInfo.Where(info => !string.IsNullOrEmpty(info)).Select(info => $" [{info}]"));
 
-            title += " [WEB]";
+            title += $" [{SourceTag}]";
             return title;
         }
 

--- a/src/Sleezer/Download/Clients/Soulseek/ISlskdApiClient.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/ISlskdApiClient.cs
@@ -1,5 +1,6 @@
 using FluentValidation.Results;
 using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
 
 namespace NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
 
@@ -19,7 +20,7 @@ public class SlskdEventRecord
 
 public interface ISlskdApiClient
 {
-    Task<(List<string> Enqueued, List<string> Failed)> EnqueueDownloadAsync(SlskdProviderSettings settings, string username, IEnumerable<(string Filename, long Size)> files);
+    Task<SlskdEnqueueResult> EnqueueDownloadAsync(SlskdProviderSettings settings, string username, IEnumerable<(string Filename, long Size)> files, string? externalId = null, string? destination = null);
     Task<List<SlskdUserTransfers>> GetAllTransfersAsync(SlskdProviderSettings settings, bool includeRemoved = false);
     Task<SlskdUserTransfers?> GetUserTransfersAsync(SlskdProviderSettings settings, string username);
     Task<SlskdDownloadFile?> GetTransferAsync(SlskdProviderSettings settings, string username, string fileId);
@@ -27,6 +28,7 @@ public interface ISlskdApiClient
     Task DeleteTransferAsync(SlskdProviderSettings settings, string username, string fileId, bool remove = false);
     Task DeleteAllCompletedAsync(SlskdProviderSettings settings);
     Task<string?> GetDownloadPathAsync(SlskdProviderSettings settings);
+    Task<SlskdDestinationConfig?> GetDestinationConfigAsync(SlskdProviderSettings settings);
     Task<ValidationFailure?> TestConnectionAsync(SlskdProviderSettings settings);
     Task<(List<SlskdEventRecord> Events, int TotalCount)> GetEventsAsync(SlskdProviderSettings settings, int offset, int limit);
 }

--- a/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
@@ -34,6 +34,7 @@ public class SlskdDownloadItem
     // aggregates them and exposes a merged view through SlskdDownloadDirectory.
     private readonly Dictionary<string, SlskdDownloadDirectory> _remoteDirectories = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _enqueuedFilenames;
+    private readonly HashSet<string> _enqueueFailedFilenames = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SlskdFileState> _previousFileStates = [];
 
     public List<Task> PostProcessTasks { get; } = [];
@@ -80,6 +81,19 @@ public class SlskdDownloadItem
     /// <summary>True when this item enqueued the given remote file.</summary>
     public bool OwnsFile(string? remoteFilename) =>
         !string.IsNullOrEmpty(remoteFilename) && _enqueuedFilenames.Contains(remoteFilename);
+
+    /// <summary>
+    /// Records files slskd rejected at enqueue time. They will never produce a
+    /// transfer, so completion tracking must not wait for them.
+    /// </summary>
+    public void MarkEnqueueFailed(IEnumerable<string> filenames)
+    {
+        foreach (string filename in filenames)
+            _enqueueFailedFilenames.Add(filename);
+    }
+
+    /// <summary>Files that were actually accepted by slskd.</summary>
+    public int ExpectedFileCount => Math.Max(0, FileData.Count - _enqueueFailedFilenames.Count);
 
     /// <summary>True when this item tracks transfers for the given remote directory.</summary>
     public bool TracksRemoteDirectory(string? remoteDirectory) =>
@@ -215,8 +229,10 @@ public class SlskdDownloadItem
     {
         // slskd's own placement report (event localDirectoryName) or the
         // batch/pattern-derived prediction wins over leaf-name guessing.
+        // Peer/remote-influenced, so fail closed on any relative segment.
         string? knownSubdirectory = ConfirmedSubdirectory ?? DerivedSubdirectory;
-        if (!string.IsNullOrEmpty(knownSubdirectory))
+        if (!string.IsNullOrEmpty(knownSubdirectory) &&
+            !knownSubdirectory.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries).Any(s => s is "." or ".."))
             return new OsPath(Path.Combine(downloadPath.FullPath, knownSubdirectory.Replace('/', Path.DirectorySeparatorChar)));
 
         // Multi-disc: slskd downloads each remote disc directory into its own

--- a/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
@@ -39,6 +39,22 @@ public class SlskdDownloadItem
     public List<Task> PostProcessTasks { get; } = [];
     public DownloadItemStatus? LastReportedStatus { get; set; }
     public bool DiscFoldersMerged { get; set; }
+
+    /// <summary>Batch id when the batch enqueue endpoint accepted the download.</summary>
+    public string? BatchId { get; set; }
+
+    /// <summary>
+    /// Local subfolder (relative to the downloads directory) slskd reported via
+    /// a DownloadDirectoryComplete event — ground truth when present.
+    /// </summary>
+    public string? ConfirmedSubdirectory { get; set; }
+
+    /// <summary>
+    /// Local subfolder predicted from the batch destination or the configured
+    /// subdirectory pattern before any event confirms it.
+    /// </summary>
+    public string? DerivedSubdirectory { get; set; }
+
     public IReadOnlyDictionary<string, SlskdFileState> FileStates => _previousFileStates;
 
     public SlskdDownloadDirectory? SlskdDownloadDirectory
@@ -197,6 +213,12 @@ public class SlskdDownloadItem
 
     public OsPath GetFullFolderPath(OsPath downloadPath)
     {
+        // slskd's own placement report (event localDirectoryName) or the
+        // batch/pattern-derived prediction wins over leaf-name guessing.
+        string? knownSubdirectory = ConfirmedSubdirectory ?? DerivedSubdirectory;
+        if (!string.IsNullOrEmpty(knownSubdirectory))
+            return new OsPath(Path.Combine(downloadPath.FullPath, knownSubdirectory.Replace('/', Path.DirectorySeparatorChar)));
+
         // Multi-disc: slskd downloads each remote disc directory into its own
         // local folder; the manager merges those into one album folder after
         // completion, and that folder is what Lidarr imports.

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdApiClient.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdApiClient.cs
@@ -5,6 +5,7 @@ using NzbDrone.Core.Download.Clients;
 using System.Net;
 using System.Text.Json;
 using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
 
 namespace NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
 
@@ -50,29 +51,106 @@ public class SlskdApiClient(IHttpClient httpClient, Logger logger) : ISlskdApiCl
         }
     }
 
-    public async Task<(List<string> Enqueued, List<string> Failed)> EnqueueDownloadAsync(
-        SlskdProviderSettings settings, string username, IEnumerable<(string Filename, long Size)> files)
+    public async Task<SlskdEnqueueResult> EnqueueDownloadAsync(
+        SlskdProviderSettings settings, string username, IEnumerable<(string Filename, long Size)> files, string? externalId = null, string? destination = null)
     {
         await _enqueueLimiter.WaitAsync();
         try
         {
-            string payload = JsonSerializer.Serialize(files.Select(f => new { f.Filename, f.Size }));
-            HttpRequest request = BuildRequest(
+            List<(string Filename, long Size)> fileList = files.ToList();
+
+            // Newer slskd exposes a batch endpoint that reports per-file
+            // failures and accepts a destination subfolder (used to land all
+            // discs of a multi-disc grab in one album folder). Fall back to the
+            // legacy all-or-nothing endpoint when it's absent.
+            SlskdEnqueueResult? batchResult = await TryEnqueueBatchAsync(settings, username, fileList, externalId, destination);
+            if (batchResult != null)
+                return batchResult;
+
+            string payload = JsonSerializer.Serialize(fileList.Select(f => new { f.Filename, f.Size }));
+            HttpResponse response = await httpClient.ExecuteAsync(BuildRequest(
                 settings,
                 $"/api/v0/transfers/downloads/{Uri.EscapeDataString(username)}",
                 HttpMethod.Post,
-                payload);
-            HttpResponse response = await httpClient.ExecuteAsync(request);
+                payload));
 
             if (response.StatusCode != HttpStatusCode.Created)
                 throw new DownloadClientException($"Enqueue failed for {username}. Status: {response.StatusCode}");
 
-            return ([], []);
+            return new SlskdEnqueueResult(null, fileList.Select(f => f.Filename).ToList(), []);
         }
         finally
         {
             _enqueueLimiter.Release();
         }
+    }
+
+    private async Task<SlskdEnqueueResult?> TryEnqueueBatchAsync(
+        SlskdProviderSettings settings, string username, List<(string Filename, long Size)> files, string? externalId, string? destination)
+    {
+        string batchId = Guid.NewGuid().ToString();
+        string payload = JsonSerializer.Serialize(new
+        {
+            id = batchId,
+            username,
+            files = files.Select(f => new { filename = f.Filename, size = f.Size }),
+            options = new { externalId, destination }
+        });
+
+        for (int attempt = 0; ; attempt++)
+        {
+            HttpRequest request = BuildRequest(settings, "/api/v0/transfers/downloads/batches", HttpMethod.Post, payload);
+            request.SuppressHttpError = true;
+            HttpResponse response = await httpClient.ExecuteAsync(request);
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.Created:
+                    return new SlskdEnqueueResult(batchId, files.Select(f => f.Filename).ToList(), []);
+
+                case HttpStatusCode.OK:
+                case HttpStatusCode.MultiStatus:
+                    return ParseBatchResponse(files, response.Content);
+
+                // Older slskd without the batch endpoint — signal legacy fallback.
+                case HttpStatusCode.BadRequest when response.Content?.Contains("QueueDownloadRequest", StringComparison.OrdinalIgnoreCase) == true:
+                case HttpStatusCode.MethodNotAllowed:
+                case HttpStatusCode.NotFound when IsEndpointMissing(response):
+                    logger.Debug("[slskd] batch download endpoint unavailable; using legacy enqueue for {Username}", username);
+                    return null;
+
+                case HttpStatusCode.NotFound:
+                    throw new DownloadClientException($"Enqueue failed for {username}: user appears to be offline.");
+
+                case HttpStatusCode.TooManyRequests when attempt < 2:
+                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    continue;
+
+                default:
+                    throw new DownloadClientException($"Batch enqueue failed for {username}. Status: {response.StatusCode}");
+            }
+        }
+
+        SlskdEnqueueResult ParseBatchResponse(List<(string Filename, long Size)> requested, string content)
+        {
+            List<SlskdEnqueueFailure> failures = [];
+
+            using JsonDocument doc = JsonDocument.Parse(content);
+            if (doc.RootElement.TryGetProperty("failures", out JsonElement failuresEl) &&
+                failuresEl.ValueKind == JsonValueKind.Array)
+            {
+                failures = failuresEl.Deserialize<List<SlskdEnqueueFailure>>() ?? [];
+            }
+
+            HashSet<string> failedNames = failures.Select(f => f.Filename).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            List<string> enqueued = requested.Select(f => f.Filename).Where(f => !failedNames.Contains(f)).ToList();
+
+            return new SlskdEnqueueResult(batchId, enqueued, failures);
+        }
+
+        static bool IsEndpointMissing(HttpResponse response) =>
+            string.IsNullOrWhiteSpace(response.Content) ||
+            !response.Content.Contains("offline", StringComparison.OrdinalIgnoreCase);
     }
 
     public async Task<List<SlskdUserTransfers>> GetAllTransfersAsync(SlskdProviderSettings settings, bool includeRemoved = false)
@@ -171,7 +249,10 @@ public class SlskdApiClient(IHttpClient httpClient, Logger logger) : ISlskdApiCl
         await httpClient.ExecuteAsync(
             BuildRequest(settings, "/api/v0/transfers/downloads/all/completed", HttpMethod.Delete));
 
-    public async Task<string?> GetDownloadPathAsync(SlskdProviderSettings settings)
+    public async Task<string?> GetDownloadPathAsync(SlskdProviderSettings settings) =>
+        (await GetDestinationConfigAsync(settings))?.DownloadsDirectory;
+
+    public async Task<SlskdDestinationConfig?> GetDestinationConfigAsync(SlskdProviderSettings settings)
     {
         HttpResponse response = await ExecuteGetWithRetryAsync(BuildRequest(settings, "/api/v0/options"));
 
@@ -179,11 +260,7 @@ public class SlskdApiClient(IHttpClient httpClient, Logger logger) : ISlskdApiCl
             return null;
 
         using JsonDocument doc = JsonDocument.Parse(response.Content);
-        if (doc.RootElement.TryGetProperty("directories", out JsonElement dirs) &&
-            dirs.TryGetProperty("downloads", out JsonElement dl))
-            return dl.GetString();
-
-        return null;
+        return SlskdDestinationConfig.FromOptions(doc.RootElement);
     }
 
     public async Task<ValidationFailure?> TestConnectionAsync(SlskdProviderSettings settings)
@@ -220,7 +297,9 @@ public class SlskdApiClient(IHttpClient httpClient, Logger logger) : ISlskdApiCl
             if (string.IsNullOrEmpty(serverState) || !serverState.Contains("Connected"))
                 return new ValidationFailure("BaseUrl", $"Slskd server is not connected. State: {serverState}");
 
-            settings.DownloadPath = await GetDownloadPathAsync(settings) ?? string.Empty;
+            SlskdDestinationConfig? destinationConfig = await GetDestinationConfigAsync(settings);
+            settings.DownloadPath = destinationConfig?.DownloadsDirectory ?? string.Empty;
+            settings.SubdirectoryPattern = destinationConfig?.SubdirectoryPattern;
             if (string.IsNullOrEmpty(settings.DownloadPath))
                 return new ValidationFailure("DownloadPath", "DownloadPath could not be found or is invalid.");
 

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -179,8 +179,15 @@ public class SlskdDownloadManager : ISlskdDownloadManager
                     $"All {result.Failed.Count} files failed to enqueue: {string.Join("; ", result.Failed.Select(f => $"{Path.GetFileName(f.Filename)}: {f.Message}"))}");
 
             if (result.Failed.Count > 0)
+            {
                 _logger.Warn("{Failed} of {Total} files failed to enqueue for {Username}: {Messages}",
                     result.Failed.Count, files.Count, username, string.Join("; ", result.Failed.Select(f => f.Message).Distinct()));
+
+                // Rejected files never produce a transfer — exclude them from
+                // completion tracking so the item can still finish, import its
+                // partial content, and let Lidarr re-search for the gaps.
+                item.MarkEnqueueFailed(result.Failed.Select(f => f.Filename));
+            }
 
             item.BatchId = result.BatchId;
             if (destination != null && result.BatchId != null)
@@ -547,8 +554,9 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             return false;
 
         // Multi-disc: transfer state arrives per remote directory, so wait until
-        // every enqueued file has reported before declaring the album complete.
-        if (item.FileData.Count > 0 && states.Count < item.FileData.Count)
+        // every ACCEPTED file has reported before declaring the album complete
+        // (enqueue-rejected files never produce a transfer).
+        if (item.ExpectedFileCount > 0 && states.Count < item.ExpectedFileCount)
             return false;
 
         foreach (SlskdFileState state in states.Values)

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -2,6 +2,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.Download.History;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
@@ -167,7 +168,28 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             string username = ExtractUsernameFromPath(remoteAlbum.Release.DownloadUrl);
             List<(string Filename, long Size)> files = ParseFilesFromSource(remoteAlbum.Release.Source);
 
-            await _apiClient.EnqueueDownloadAsync(settings, username, files);
+            // Multi-disc: ask slskd (batch endpoint) to land every file in one
+            // album-named destination folder, so no local merge is needed.
+            string? destination = item.IsMultiDirectory ? SanitizeFolderName(item.LocalAlbumFolderName()) : null;
+
+            SlskdEnqueueResult result = await _apiClient.EnqueueDownloadAsync(settings, username, files, externalId: item.ID, destination: destination);
+
+            if (result.AllFailed)
+                throw new DownloadClientException(
+                    $"All {result.Failed.Count} files failed to enqueue: {string.Join("; ", result.Failed.Select(f => $"{Path.GetFileName(f.Filename)}: {f.Message}"))}");
+
+            if (result.Failed.Count > 0)
+                _logger.Warn("{Failed} of {Total} files failed to enqueue for {Username}: {Messages}",
+                    result.Failed.Count, files.Count, username, string.Join("; ", result.Failed.Select(f => f.Message).Distinct()));
+
+            item.BatchId = result.BatchId;
+            if (destination != null && result.BatchId != null)
+            {
+                // slskd honors the destination itself — no post-download merge.
+                item.DerivedSubdirectory = destination;
+                item.DiscFoldersMerged = true;
+            }
+
             item.Username = username;
             SubscribeStateChanges(item, definitionId);
             AddItem(definitionId, item);
@@ -451,7 +473,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             // transfers per remote directory — the per-directory hash never
             // matches, so fall back to matching by enqueued-file membership.
             SlskdDownloadItem? item = GetItem(definitionId, hash)
-                ?? FindItemOwningDirectory(definitionId, dir);
+                ?? FindItemOwningDirectory(definitionId, userTransfers.Username, dir);
             if (item == null)
             {
                 _logger.Trace("[def={DefinitionId}] Unknown item {Hash}: checking history", definitionId, hash);
@@ -476,6 +498,20 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             item.Username ??= userTransfers.Username;
             item.SlskdDownloadDirectory = dir;
 
+            // With a non-default subdirectory pattern, slskd places transfers
+            // somewhere the leaf-name guess can't predict — derive it.
+            if (item.DerivedSubdirectory == null && item.ConfirmedSubdirectory == null &&
+                settings.GetDestinationConfig() is { UsesDefaultPattern: false } destinationConfig &&
+                dir.Files?.FirstOrDefault()?.Filename is { Length: > 0 } firstFile)
+            {
+                item.DerivedSubdirectory = SlskdPathResolver.ResolveSubdirectory(
+                    destinationConfig,
+                    userTransfers.Username,
+                    firstFile,
+                    item.BatchId,
+                    item.BatchId != null ? item.ID : null);
+            }
+
             // Fallback trigger for post-process: if the transfer poll sees all
             // files completed before the event poll has caught up with the matching
             // DownloadDirectoryComplete event, enqueue here. Without this, Lidarr
@@ -486,13 +522,22 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         }
     }
 
-    private SlskdDownloadItem? FindItemOwningDirectory(int definitionId, SlskdDownloadDirectory dir)
+    private SlskdDownloadItem? FindItemOwningDirectory(int definitionId, string username, SlskdDownloadDirectory dir)
     {
         string? probeFile = dir.Files?.FirstOrDefault()?.Filename;
         if (string.IsNullOrEmpty(probeFile))
             return null;
 
-        return GetItemsForDef(definitionId).FirstOrDefault(i => i.OwnsFile(probeFile));
+        return GetItemsForDef(definitionId).FirstOrDefault(i =>
+            (i.Username == null || string.Equals(i.Username, username, StringComparison.OrdinalIgnoreCase)) &&
+            i.OwnsFile(probeFile));
+    }
+
+    private static string SanitizeFolderName(string name)
+    {
+        foreach (char c in Path.GetInvalidFileNameChars())
+            name = name.Replace(c, '_');
+        return name;
     }
 
     private static bool AllFilesCompleted(SlskdDownloadItem item)
@@ -544,6 +589,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             using JsonDocument doc = JsonDocument.Parse(record.Data);
             string remoteDir = doc.RootElement.TryGetProperty("remoteDirectoryName", out JsonElement rdn) ? rdn.GetString() ?? "" : "";
             string username = doc.RootElement.TryGetProperty("username", out JsonElement un) ? un.GetString() ?? "" : "";
+            string? localDir = doc.RootElement.TryGetProperty("localDirectoryName", out JsonElement ldn) ? ldn.GetString() : null;
 
             _logger.Trace("[def={DefinitionId}] Event DownloadDirectoryComplete: {RemoteDir} by {Username}: forcing refresh", definitionId, remoteDir, username);
 
@@ -561,6 +607,16 @@ public class SlskdDownloadManager : ISlskdDownloadManager
 
             if (item != null)
             {
+                // slskd tells us exactly where it put the files — ground truth
+                // for OutputPath, especially under custom subdirectory patterns
+                // or batch destinations. Single-directory items only: for
+                // multi-disc the per-disc local folder is not the album folder.
+                if (!item.IsMultiDirectory || item.BatchId != null)
+                {
+                    item.ConfirmedSubdirectory = SlskdPathResolver.MakeRelativeToDownloads(settings.DownloadPath, localDir)
+                        ?? item.ConfirmedSubdirectory;
+                }
+
                 // Multi-disc items get one DownloadDirectoryComplete per disc;
                 // only post-process once every enqueued file is done.
                 if (AllFilesCompleted(item))
@@ -902,15 +958,15 @@ public class SlskdDownloadManager : ISlskdDownloadManager
 
             try
             {
-                string relativePath = file.Filename;
-                if (relativePath.StartsWith(settings.DownloadPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    relativePath = relativePath.Substring(settings.DownloadPath.Length).TrimStart('/', '\\');
-                }
-
-                string localFilePath = _remotePathMappingService
-                    .RemapRemoteToLocal(settings.Host, new OsPath(Path.Combine(settings.DownloadPath, relativePath)))
-                    .FullPath;
+                // file.Filename is the REMOTE path — only its basename exists
+                // locally, inside the item's resolved output folder. The old
+                // remote-path concatenation never matched a real local file.
+                string fileName = Path.GetFileName(file.Filename.Replace('\\', '/'));
+                string localFilePath = Path.Combine(
+                    _remotePathMappingService
+                        .RemapRemoteToLocal(settings.Host, item.GetFullFolderPath(new OsPath(settings.DownloadPath)))
+                        .FullPath,
+                    fileName);
 
                 if (_diskProvider.FileExists(localFilePath))
                 {

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdPathResolver.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdPathResolver.cs
@@ -61,9 +61,18 @@ public static partial class SlskdPathResolver
         if (path.Equals(root, StringComparison.OrdinalIgnoreCase))
             return string.Empty;
 
-        return path.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase)
-            ? path[(root.Length + 1)..]
-            : null;
+        if (!path.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        string relative = path[(root.Length + 1)..];
+
+        // The event payload is not fully under our control — fail closed on
+        // relative segments ("root//../x" passes the prefix check above).
+        string[] segments = relative.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(s => s is "." or ".."))
+            return null;
+
+        return string.Join('/', segments);
     }
 
     private static string Normalize(string path) => path.Replace('\\', '/');

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdPathResolver.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdPathResolver.cs
@@ -1,0 +1,94 @@
+using System.Text.RegularExpressions;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
+
+namespace NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
+
+/// <summary>
+/// Resolves where slskd places a transfer locally when
+/// transfers.download.destination.subdirectory is configured to a non-default
+/// pattern. Ported from TypNull/Tubifarry d857a0f.
+/// </summary>
+public static partial class SlskdPathResolver
+{
+    public static string? ResolveSubdirectory(
+        SlskdDestinationConfig config, string username, string remoteFilename, string? batchId = null, string? externalId = null)
+    {
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(remoteFilename))
+            return null;
+
+        string pattern = config.SubdirectoryPattern ?? SlskdDestinationConfig.DefaultPattern;
+        if (pattern.Equals("{}", StringComparison.OrdinalIgnoreCase))
+            return string.Empty;
+
+        string[] sourceSegments = SplitSegments(StripRoot(remoteFilename)).SkipLast(1).ToArray();
+        string sourcePath = string.Join('/', sourceSegments);
+        string sourceDirectory = sourceSegments.LastOrDefault() ?? string.Empty;
+
+        Dictionary<string, string> tokens = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["SOURCE_USERNAME"] = username,
+            ["SOURCE_PATH"] = sourcePath,
+            ["SOURCE_DIRECTORY"] = sourceDirectory,
+            ["BATCH_ID"] = batchId ?? "unknown_batch_id",
+            ["BATCH_EXTERNAL_ID"] = externalId ?? "unknown_batch_external_id",
+            ["SEARCH_ID"] = "unknown_search_id",
+            ["SEARCH_TEXT"] = "unknown_search_text",
+        };
+
+        string destination = TokenRegex().Replace(pattern, match =>
+            tokens.TryGetValue(match.Groups[1].Value, out string? value) ? value : match.Value);
+
+        string[] segments = SplitSegments(destination);
+        if (segments.Any(s => s is "." or ".."))
+            return null;
+
+        return string.Join('/', segments);
+    }
+
+    /// <summary>
+    /// Turns slskd's absolute localDirectoryName (from DownloadDirectoryComplete
+    /// events) into a path relative to the downloads directory; null when the
+    /// path is outside it.
+    /// </summary>
+    public static string? MakeRelativeToDownloads(string downloadsDirectory, string? absolutePath)
+    {
+        if (string.IsNullOrWhiteSpace(downloadsDirectory) || string.IsNullOrWhiteSpace(absolutePath))
+            return null;
+
+        string root = Normalize(downloadsDirectory).TrimEnd('/');
+        string path = Normalize(absolutePath).TrimEnd('/');
+
+        if (path.Equals(root, StringComparison.OrdinalIgnoreCase))
+            return string.Empty;
+
+        return path.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase)
+            ? path[(root.Length + 1)..]
+            : null;
+    }
+
+    private static string Normalize(string path) => path.Replace('\\', '/');
+
+    private static string[] SplitSegments(string path) =>
+        Normalize(path).Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+    private static string StripRoot(string path)
+    {
+        path = Normalize(path);
+        path = DriveRootRegex().Replace(path, string.Empty);
+        path = UncRootRegex().Replace(path, string.Empty);
+        path = SoulseekQtRootRegex().Replace(path, string.Empty);
+        return path;
+    }
+
+    [GeneratedRegex(@"\$\{([^\{\}]*)\}", RegexOptions.IgnoreCase)]
+    private static partial Regex TokenRegex();
+
+    [GeneratedRegex(@"^[a-zA-Z]:/?")]
+    private static partial Regex DriveRootRegex();
+
+    [GeneratedRegex(@"^//[^/]+/?")]
+    private static partial Regex UncRootRegex();
+
+    [GeneratedRegex(@"^@@[a-zA-Z0-9]{5,}/?")]
+    private static partial Regex SoulseekQtRootRegex();
+}

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -3,6 +3,7 @@ using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using System.Text.RegularExpressions;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
 
 namespace NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek
 {
@@ -105,6 +106,13 @@ namespace NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek
         public bool IsLocalhost { get; set; }
 
         public string DownloadPath { get; set; } = string.Empty;
+
+        // slskd's transfers.download.destination.subdirectory pattern, fetched
+        // alongside DownloadPath during Test. Null/default = per-source-folder.
+        public string? SubdirectoryPattern { get; set; }
+
+        public SlskdDestinationConfig? GetDestinationConfig() =>
+            string.IsNullOrEmpty(DownloadPath) ? null : new SlskdDestinationConfig(DownloadPath, SubdirectoryPattern);
 
         public TimeSpan? GetTimeout() => TimeoutMinutes == null ? null : TimeSpan.FromMinutes(TimeoutMinutes.Value);
 

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdRetryHandler.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdRetryHandler.cs
@@ -41,7 +41,7 @@ public class SlskdRetryHandler(ISlskdApiClient apiClient, Logger logger)
             long size = matchingEl.TryGetProperty("Size", out JsonElement sz) ? sz.GetInt64() : 0L;
             string username = item.Username ?? ExtractUsernameFromPath(item.ReleaseInfo.DownloadUrl);
 
-            await _apiClient.EnqueueDownloadAsync(settings, username, [(fileState.File.Filename, size)]);
+            await _apiClient.EnqueueDownloadAsync(settings, username, [(fileState.File.Filename, size)], externalId: item.ID);
             _logger.Trace("Retry enqueued: {Filename}", Path.GetFileName(fileState.File.Filename));
         }
         catch (Exception ex)

--- a/src/Sleezer/Indexers/Soulseek/Search/Core/SearchPipeline.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Core/SearchPipeline.cs
@@ -84,6 +84,11 @@ public sealed class SearchPipeline : ISlskdSearchChain
         if (string.IsNullOrWhiteSpace(query))
             return [];
 
+        query = ResolveRestrictedTerms(query);
+
+        if (string.IsNullOrWhiteSpace(query))
+            return [];
+
         if (context.ProcessedSearches.Contains(query))
         {
             _logger.Trace("[{Strategy}] Skip duplicate: '{Query}'", strategy.Name, query);
@@ -110,5 +115,29 @@ public sealed class SearchPipeline : ISlskdSearchChain
             _logger.Error(ex, "[{Strategy}] Error: '{Query}'", strategy.Name, query);
             return [];
         }
+    }
+
+    // The Soulseek server silently filters searches containing certain terms
+    // (mostly DMCA-listed artist names) — they return zero results network-wide.
+    // Rewrite the query with an injected accent so it slips past the filter;
+    // if no rewrite survives, drop the query (BlockedTermEvidenceStrategy
+    // provides the artist-less fallback).
+    private string ResolveRestrictedTerms(string query)
+    {
+        if (!SlskdTextProcessor.ContainsBlockedTerms(query))
+            return query;
+
+        for (int variant = 0; variant < 3; variant++)
+        {
+            string candidate = SlskdTextProcessor.RewriteRestrictedTerms(query, variant);
+            if (candidate != query && !SlskdTextProcessor.ContainsBlockedTerms(candidate))
+            {
+                _logger.Debug("Rewrote server-blocked search term: '{Query}' -> '{Candidate}'", query, candidate);
+                return candidate;
+            }
+        }
+
+        _logger.Debug("Dropping query containing server-blocked term with no viable rewrite: '{Query}'", query);
+        return string.Empty;
     }
 }

--- a/src/Sleezer/Indexers/Soulseek/Search/Strategies/BlockedTermEvidenceStrategy.cs
+++ b/src/Sleezer/Indexers/Soulseek/Search/Strategies/BlockedTermEvidenceStrategy.cs
@@ -1,0 +1,53 @@
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Core;
+
+namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek.Search.Strategies;
+
+/// <summary>
+/// Last-resort strategy for artists the Soulseek server silently censors:
+/// drops the blocked term and searches for the album plus its most distinctive
+/// track title instead, relying on the parser's track-title evidence to
+/// confirm the match. Ported from TypNull/Tubifarry ae3ce28.
+/// </summary>
+public sealed class BlockedTermEvidenceStrategy : SearchStrategyBase
+{
+    public override string Name => "Blocked Term Evidence";
+    public override SearchTier Tier => SearchTier.Fallback;
+    public override int Priority => 50;
+
+    public override bool CanExecute(SearchContext context, QueryType queryType)
+        => SlskdTextProcessor.ContainsBlockedTerms(BuildRawQuery(context));
+
+    public override string? GetQuery(SearchContext context, QueryType queryType)
+    {
+        string strippedQuery = SlskdTextProcessor.RemoveBlockedTerms(BuildRawQuery(context));
+
+        foreach (string evidenceTrack in SlskdTextProcessor.GetBlockedTermEvidenceTracks(context.Tracks, context.SearchAlbum))
+        {
+            string candidate = CombineQueryWithEvidence(strippedQuery, evidenceTrack);
+            if (!context.ProcessedSearches.Contains(candidate))
+                return candidate;
+        }
+
+        if (context.HasValidYear && !string.IsNullOrWhiteSpace(strippedQuery))
+        {
+            string queryWithYear = $"{strippedQuery} {context.Year}";
+            if (!context.ProcessedSearches.Contains(queryWithYear))
+                return queryWithYear;
+        }
+
+        return string.IsNullOrWhiteSpace(strippedQuery) ? null : strippedQuery;
+    }
+
+    private static string CombineQueryWithEvidence(string strippedQuery, string evidenceTrack)
+    {
+        if (string.IsNullOrWhiteSpace(strippedQuery))
+            return evidenceTrack;
+
+        return strippedQuery.Contains(evidenceTrack, StringComparison.OrdinalIgnoreCase)
+            ? strippedQuery
+            : $"{strippedQuery} {evidenceTrack}";
+    }
+
+    private static string BuildRawQuery(SearchContext context)
+        => SlskdTextProcessor.BuildSearchText(context.SearchArtist, context.SearchAlbum);
+}

--- a/src/Sleezer/Indexers/Soulseek/SlsdkRecords.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlsdkRecords.cs
@@ -114,12 +114,27 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 score += Math.Min(1800, (int)(Math.Log10(Math.Max(0.1, speedMbps) + 1) * 1100));
             }
 
-            // ===== QUEUE LENGTH (50 to +1500) =====
-            double queueFactor = Math.Pow(0.94, Math.Min(QueueLength, 40));
-            score += (int)(queueFactor * 1500);
+            // ===== QUEUE LENGTH x FREE SLOT (0 to +2300, multiplicative) =====
+            // Multiplicative so a 40-deep queue with a nominally free slot no
+            // longer outranks an empty queue without one.
+            double queueFactor = Math.Pow(0.94, Math.Min(QueueLength, 60));
+            double slotFactor = HasFreeUploadSlot ? 1.0 : 0.35;
+            score += (int)(queueFactor * slotFactor * 2300);
 
-            // ===== FREE UPLOAD SLOT (0 or +800) =====
-            score += HasFreeUploadSlot ? 800 : 0;
+            // ===== FILE CONSISTENCY (0 to +300) =====
+            // Uniform extensions and present duration metadata suggest a clean
+            // rip rather than a mixed grab-bag folder.
+            if (Files.Count > 0)
+            {
+                int distinctExtensions = Files
+                    .Select(f => (f.Extension ?? System.IO.Path.GetExtension(f.Filename) ?? string.Empty).ToLowerInvariant())
+                    .Where(ext => ext.Length > 0)
+                    .Distinct()
+                    .Count();
+
+                double durationCoverage = Files.Count(f => f.Length is > 0) / (double)Files.Count;
+                score += (int)((distinctExtensions <= 1 ? 150 : 0) + durationCoverage * 150);
+            }
 
             // ===== COLLECTION SIZE (0 to +300) =====
             score += Math.Min(300, (int)(Math.Log10(Math.Max(1, FileCount) + 1) * 150));
@@ -135,10 +150,65 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         [property: JsonPropertyName("expandDirectory")] bool ExpandDirectory,
         [property: JsonPropertyName("mimimumFiles")] int MinimumFiles,
         [property: JsonPropertyName("maximumFiles")] int? MaximumFiles,
-        [property: JsonPropertyName("trackCount")] int TrackCount = 0)
+        [property: JsonPropertyName("trackCount")] int TrackCount = 0,
+        [property: JsonPropertyName("tracks")] List<string>? Tracks = null)
     {
         private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
         public static SlskdSearchData FromJson(string jsonString) => JsonSerializer.Deserialize<SlskdSearchData>(jsonString, _jsonOptions)!;
+    }
+
+    public record SlskdEnqueueFailure(
+        [property: JsonPropertyName("filename")] string Filename,
+        [property: JsonPropertyName("message")] string Message
+    );
+
+    public record SlskdEnqueueResult(string? BatchId, List<string> Enqueued, List<SlskdEnqueueFailure> Failed)
+    {
+        public bool AllFailed => Enqueued.Count == 0 && Failed.Count > 0;
+    }
+
+    /// <summary>
+    /// slskd's download destination settings: the downloads directory plus the
+    /// optional transfers.download.destination.subdirectory pattern that
+    /// controls which local subfolder each transfer lands in.
+    /// </summary>
+    public record SlskdDestinationConfig(string DownloadsDirectory, string? SubdirectoryPattern)
+    {
+        public const string DefaultPattern = "${SOURCE_DIRECTORY}";
+
+        public bool UsesDefaultPattern =>
+            SubdirectoryPattern is null ||
+            string.Equals(SubdirectoryPattern, DefaultPattern, StringComparison.OrdinalIgnoreCase);
+
+        public static SlskdDestinationConfig? FromOptions(JsonElement options)
+        {
+            if (!options.TryGetProperty("directories", out JsonElement directories) ||
+                !directories.TryGetProperty("downloads", out JsonElement downloads) ||
+                downloads.GetString() is not { Length: > 0 } downloadsDirectory)
+                return null;
+
+            string? pattern = null;
+            if (options.TryGetProperty("transfers", out JsonElement transfers) &&
+                transfers.TryGetProperty("download", out JsonElement download) &&
+                download.TryGetProperty("destination", out JsonElement destination) &&
+                destination.TryGetProperty("subdirectory", out JsonElement subdirectory))
+                pattern = subdirectory.GetString();
+
+            return new SlskdDestinationConfig(downloadsDirectory, pattern);
+        }
+    }
+
+    public sealed record SlskdSearchRequestBody
+    {
+        public required string Id { get; init; }
+        public int FileLimit { get; init; }
+        public bool FilterResponses { get; init; }
+        public long MaximumPeerQueueLength { get; init; }
+        public int MinimumPeerUploadSpeed { get; init; }
+        public int MinimumResponseFileCount { get; init; }
+        public int ResponseLimit { get; init; }
+        public required string SearchText { get; init; }
+        public int SearchTimeout { get; init; }
     }
 
     public record SlskdDirectoryApiResponse(

--- a/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
@@ -576,11 +576,18 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             if (titles.Count == 0)
                 return 0;
 
-            string haystack = NormalizeString(string.Join(" ", files
+            // Per-file containment: a concatenated haystack lets a multi-word
+            // title spuriously match across the boundary of two filenames.
+            List<string> normalizedNames = files
                 .Select(f => Path.GetFileNameWithoutExtension(f.Filename ?? string.Empty))
-                .Select(n => TrackNumberPrefixRegex().Replace(n, string.Empty))));
+                .Select(n => NormalizeString(TrackNumberPrefixRegex().Replace(n, string.Empty)))
+                .Where(n => n.Length > 0)
+                .ToList();
 
-            return titles.Count(haystack.Contains) / (double)titles.Count;
+            if (normalizedNames.Count == 0)
+                return 0;
+
+            return titles.Count(title => normalizedNames.Any(name => name.Contains(title))) / (double)titles.Count;
         }
 
         // Non-contiguous track numbers usually mean a partial rip or a mixed

--- a/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
@@ -101,9 +101,26 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 : IsFuzzyAlbumNameMatch(dirNameNorm, searchAlbumNorm, strictnessOffset);
             bool isArtistMatch = IsFuzzyArtistMatch(dirNameNorm, searchArtistNorm, strictnessOffset);
 
+            // Path-tail retry: the album name often spans the parent+leaf
+            // components ("Artist - Album/CD extras" layouts).
+            if (!isAlbumMatch && !isVolumeSearch && !string.IsNullOrEmpty(searchAlbumNorm))
+            {
+                string[] components = SplitPathIntoComponents(directory.Key);
+                if (components.Length >= 2)
+                    isAlbumMatch = IsFuzzyAlbumNameMatch(NormalizeString($"{components[^2]} {components[^1]}"), searchAlbumNorm, strictnessOffset);
+            }
+
+            // Track-title evidence: when enough of the wanted track titles appear
+            // in the folder's filenames, the folder IS the album regardless of
+            // how it is named. Essential for server-blocked artists whose name
+            // never appears in the query or the path.
+            double trackEvidence = CalculateTrackTitleEvidence(directory, searchData.Tracks);
+            if (trackEvidence >= TrackEvidenceThreshold)
+                isAlbumMatch = true;
+
             bool matchedSearchCriteria = string.IsNullOrEmpty(searchAlbumNorm)
                 ? isArtistMatch
-                : isAlbumMatch && (isArtistMatch || string.IsNullOrEmpty(searchArtistNorm));
+                : isAlbumMatch && (isArtistMatch || string.IsNullOrEmpty(searchArtistNorm) || trackEvidence >= TrackEvidenceThreshold);
 
             if (!isArtistMatch && !isAlbumMatch && !string.IsNullOrEmpty(searchData.Artist) && !string.IsNullOrEmpty(searchData.Album))
             {
@@ -113,7 +130,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 matchedSearchCriteria = isAlbumMatch;
             }
 
-            _logger.Debug("Match results - Artist: {ArtistMatch}, Album: {AlbumMatch}", isArtistMatch, isAlbumMatch);
+            _logger.Debug("Match results - Artist: {ArtistMatch}, Album: {AlbumMatch}, TrackEvidence: {Evidence:P0}", isArtistMatch, isAlbumMatch, trackEvidence);
 
             // Determine final values for artist, album, year
             string finalArtist = DetermineFinalArtist(isArtistMatch, isAlbumMatch, folderData, searchData);
@@ -134,6 +151,10 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             string? edition = ExtractEdition(folderData.Path)?.ToUpper();
 
             int priority = folderData.CalculatePriority(expectedTrackCount);
+            priority += (int)(trackEvidence * 400);
+            if (HasTrackNumberGaps(directory))
+                priority /= 2;
+            priority = Math.Clamp(priority, 0, 10000);
 
             // Surface the peer info (was previously bracketed onto the title
             // with emoji decorations). Lidarr indexes blocklisting by
@@ -151,6 +172,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 ArtistName = finalArtist,
                 AlbumName = finalAlbum,
                 MatchedSearchCriteria = matchedSearchCriteria,
+                SourceTag = DetectSourceTag(folderData.Path),
                 ReleaseDate = finalYear,
                 ReleaseDateTime = string.IsNullOrEmpty(finalYear) || !int.TryParse(finalYear, out int yearInt)
                     ? DateTime.MinValue
@@ -210,8 +232,18 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 }
             }
 
+            // Try artist-year-album pattern ("Artist - (1994) Album", "Artist - 1994 - Album")
+            Match? match = TryMatchRegex(lastComponent, ArtistYearAlbumRegex());
+            if (match?.Groups["album"].Success == true)
+            {
+                return (
+                    match.Groups["artist"].Value.Trim(),
+                    CleanComponent(match.Groups["album"].Value),
+                    match.Groups["year"].Value.Trim());
+            }
+
             // Try artist-album-year pattern
-            Match? match = TryMatchRegex(lastComponent, ArtistAlbumYearRegex());
+            match = TryMatchRegex(lastComponent, ArtistAlbumYearRegex());
             if (match != null)
             {
                 return (
@@ -494,8 +526,94 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 return folderVersion.Success && !searchVersion.Success ? $"{searchData.Album} {folderVersion.Value}" : searchData.Album;
             }
             if (!string.IsNullOrEmpty(folderData.Album))
-                return folderData.Album;
+                return CleanFallbackAlbum(folderData.Album, searchData.Artist);
             return searchData.Album ?? "Unknown Album";
+        }
+
+        /// <summary>
+        /// Cleans a folder-derived album name before it lands in the release
+        /// title: strips share junk (usernames, dates, GUIDs) and an embedded
+        /// artist name, so Lidarr sees "Album" rather than "@user Artist Album".
+        /// </summary>
+        private static string CleanFallbackAlbum(string album, string? artist)
+        {
+            string cleaned = JunkTokenRegex().Replace(album, " ");
+
+            string normArtist = string.IsNullOrEmpty(artist) ? string.Empty : NormalizeString(artist);
+            if (normArtist.Length > 2)
+            {
+                string[] words = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                string[] artistWords = normArtist.Split(' ');
+                List<string> output = [];
+                int i = 0;
+                while (i < words.Length)
+                {
+                    if (i + artistWords.Length <= words.Length &&
+                        NormalizeString(string.Join(' ', words[i..(i + artistWords.Length)])) == normArtist)
+                    {
+                        i += artistWords.Length;
+                        continue;
+                    }
+                    output.Add(words[i]);
+                    i++;
+                }
+                if (output.Count > 0)
+                    cleaned = string.Join(' ', output);
+            }
+
+            cleaned = ReduceWhitespaceRegex().Replace(cleaned, " ").Trim(' ', '-', ':', '–');
+            return cleaned.Length >= 2 ? cleaned : album;
+        }
+
+        private const double TrackEvidenceThreshold = 0.35;
+
+        private static double CalculateTrackTitleEvidence(IEnumerable<SlskdFileData> files, List<string>? expectedTracks)
+        {
+            if (expectedTracks == null || expectedTracks.Count == 0)
+                return 0;
+
+            List<string> titles = expectedTracks.Select(NormalizeString).Where(t => t.Length >= 4).ToList();
+            if (titles.Count == 0)
+                return 0;
+
+            string haystack = NormalizeString(string.Join(" ", files
+                .Select(f => Path.GetFileNameWithoutExtension(f.Filename ?? string.Empty))
+                .Select(n => TrackNumberPrefixRegex().Replace(n, string.Empty))));
+
+            return titles.Count(haystack.Contains) / (double)titles.Count;
+        }
+
+        // Non-contiguous track numbers usually mean a partial rip or a mixed
+        // folder — penalized in priority, not excluded outright.
+        private static bool HasTrackNumberGaps(IEnumerable<SlskdFileData> files)
+        {
+            List<int> numbers = files
+                .Select(f => TrackNumberPrefixCaptureRegex().Match(Path.GetFileName(f.Filename ?? string.Empty)))
+                .Where(m => m.Success)
+                .Select(m => int.Parse(m.Groups[1].Value))
+                .Where(n => n is > 0 and <= 150)
+                .Distinct()
+                .Order()
+                .ToList();
+
+            return numbers.Count >= 3 && numbers[^1] - numbers[0] + 1 != numbers.Count;
+        }
+
+        private static string DetectSourceTag(string path)
+        {
+            Match match = SourceTagRegex().Match(path);
+            if (!match.Success)
+                return "WEB";
+
+            string value = match.Value.ToUpperInvariant();
+            return value switch
+            {
+                "VINYL" => "Vinyl",
+                "WEB" => "WEB",
+                "SACD" or "MFSL" or "MOFI" => "SACD",
+                _ when value.StartsWith("DSD") => "SACD",
+                _ => "CD"
+            };
         }
 
         private (AudioFormat Codec, int? BitRate, int? BitDepth, int? SampleRate, long TotalSize, int TotalDuration) AnalyzeAudioQuality(IGrouping<string, SlskdFileData> directory)
@@ -584,6 +702,21 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         [GeneratedRegex(@"^(?<artist>.+?)\s-\s(?<album>[^(\[]+)(?:\s*[\(\[](?<year>19\d{2}|20\d{2})[\)\]])?", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex ArtistAlbumYearRegex();
+
+        [GeneratedRegex(@"^(?<artist>.+?)\s-\s(?:[\(\[](?<year>19\d{2}|20\d{2})[\)\]]|(?<year>19\d{2}|20\d{2})\s*-)\s*(?<album>.+)$", RegexOptions.Compiled)]
+        private static partial Regex ArtistYearAlbumRegex();
+
+        [GeneratedRegex(@"(?i)@\w+|\((?:19|20)\d{2}-\d{2}-\d{2}\)|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.Compiled)]
+        private static partial Regex JunkTokenRegex();
+
+        [GeneratedRegex(@"^\s*[a-dA-D]?\d{1,3}\s*[-._) ]+\s*", RegexOptions.Compiled)]
+        private static partial Regex TrackNumberPrefixRegex();
+
+        [GeneratedRegex(@"^\s*(\d{1,3})\b", RegexOptions.Compiled)]
+        private static partial Regex TrackNumberPrefixCaptureRegex();
+
+        [GeneratedRegex(@"(?i)\b(vinyl|sacd|dsd\d*|mfsl|mofi|web|cd)\b", RegexOptions.Compiled)]
+        private static partial Regex SourceTagRegex();
 
         [GeneratedRegex(@"^[a-zA-Z]:?$|^(?:vol(?:ume)?|cd|disc|disk)\s*\d*$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
         private static partial Regex ShareRootRegex();

--- a/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -113,7 +113,14 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         private IEnumerable<IndexerRequest> ExecuteSearch(SearchQuery query)
         {
-            string? searchText = query.SearchText ?? SlskdTextProcessor.BuildSearchText(query.Artist, query.Album);
+            string? searchText = query.SearchText;
+            if (string.IsNullOrWhiteSpace(searchText))
+            {
+                // Direct path (no pipeline query) still needs the server-blocked
+                // term rewrite the pipeline normally applies.
+                searchText = SlskdTextProcessor.RewriteRestrictedTerms(
+                    SlskdTextProcessor.BuildSearchText(query.Artist, query.Album));
+            }
 
             if (string.IsNullOrWhiteSpace(searchText))
                 return [];
@@ -149,9 +156,9 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             {
                 _logger.Debug("Search: {SearchText}", searchText);
 
-                dynamic searchData = CreateSearchData(searchText);
+                SlskdSearchRequestBody searchData = CreateSearchData(searchText);
                 string searchId = searchData.Id;
-                dynamic searchRequest = CreateSearchRequest(searchData);
+                HttpRequest searchRequest = CreateSearchRequest(searchData);
 
                 await ExecuteSearchAsync(searchRequest, searchId);
 
@@ -184,20 +191,20 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             }
         }
 
-        private dynamic CreateSearchData(string searchText) => new
+        private SlskdSearchRequestBody CreateSearchData(string searchText) => new()
         {
             Id = Guid.NewGuid().ToString(),
-            Settings.FileLimit,
+            FileLimit = Settings.FileLimit,
             FilterResponses = true,
-            Settings.MaximumPeerQueueLength,
-            Settings.MinimumPeerUploadSpeed,
-            Settings.MinimumResponseFileCount,
-            Settings.ResponseLimit,
+            MaximumPeerQueueLength = Settings.MaximumPeerQueueLength,
+            MinimumPeerUploadSpeed = Settings.MinimumPeerUploadSpeed,
+            MinimumResponseFileCount = Settings.MinimumResponseFileCount,
+            ResponseLimit = Settings.ResponseLimit,
             SearchText = searchText,
             SearchTimeout = (int)(Settings.TimeoutInSeconds * 1000),
         };
 
-        private HttpRequest CreateSearchRequest(dynamic searchData)
+        private HttpRequest CreateSearchRequest(SlskdSearchRequestBody searchData)
         {
             HttpRequest searchRequest = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches")
                 .SetHeader("X-API-KEY", Settings.ApiKey)
@@ -299,16 +306,15 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 _ => null
             };
 
-            request.ContentSummary = new
-            {
-                Album = query.Album ?? "",
-                Artist = query.Artist,
-                Interactive = query.Interactive,
-                ExpandDirectory = query.ExpandDirectory,
-                MimimumFiles = minimumFiles,
-                MaximumFiles = maximumFiles,
-                TrackCount = query.TrackCount
-            }.ToJson();
+            request.ContentSummary = JsonSerializer.Serialize(new SlskdSearchData(
+                Artist: query.Artist,
+                Album: query.Album ?? "",
+                Interactive: query.Interactive,
+                ExpandDirectory: query.ExpandDirectory,
+                MinimumFiles: minimumFiles,
+                MaximumFiles: maximumFiles,
+                TrackCount: query.TrackCount,
+                Tracks: query.Tracks.Take(50).ToList()));
 
             return request;
         }

--- a/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
@@ -22,6 +22,41 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         private static readonly Regex VolumePattern = new(@"(Vol(?:ume)?\.?)\s*([0-9]+|[IVXLCDM]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RomanNumeralPattern = new(@"\b([IVXLCDM]+)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        // Terms the Soulseek SERVER silently filters — any search containing one
+        // returns zero results network-wide, regardless of client. Discovered
+        // empirically upstream (TypNull/Tubifarry ae3ce28); mostly DMCA-listed
+        // artists plus a few collateral words. Case-insensitive whole-word match.
+        private static readonly HashSet<string> BlockedSearchTerms = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "beyonce",
+            "Beyoncé",
+            "beyoncè",
+            "gorillaz",
+            "depeche mode",
+            "village people",
+            "chicane",
+            "bryan",
+            "cat power",
+            "lady gaga",
+            "michael jackson",
+            "beatles",
+            "adele",
+            "ymca",
+            "lemonade",
+            "macho man",
+            "rihanna",
+            "weeknd",
+            "kanye west",
+            "kendrick lamar",
+            "frank ocean",
+            "minaj",
+            "linkin park"
+        };
+
+        private static readonly string[][] BlockedTermWords = [.. BlockedSearchTerms
+            .OrderByDescending(t => t.Length)
+            .Select(t => t.Split(' ', StringSplitOptions.RemoveEmptyEntries))];
+
         public static string BuildSearchText(string? artist, string? album)
             => string.Join(" ", new[] { album, artist }.Where(term => !string.IsNullOrWhiteSpace(term)).Select(term => term?.Trim()));
 
@@ -67,6 +102,17 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         public static string NormalizeSpecialCharacters(string? input)
         {
             if (string.IsNullOrEmpty(input)) return string.Empty;
+
+            bool isAscii = true;
+            foreach (char c in input)
+            {
+                if (c > 127)
+                {
+                    isAscii = false;
+                    break;
+                }
+            }
+            if (isAscii) return input;
 
             string decomposed = input.Normalize(NormalizationForm.FormD);
             StringBuilder sb = new(decomposed.Length);
@@ -129,6 +175,127 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 yield return album.Replace(romanMatch.Value, arabicNumber.ToString());
         }
 
+        /// <summary>
+        /// Removes any blocked term (whole-word, case-insensitive) from a query.
+        /// </summary>
+        public static string RemoveBlockedTerms(string searchText)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
+                return string.Empty;
+
+            string[] words = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            bool[] removed = new bool[words.Length];
+
+            foreach (string[] termWords in BlockedTermWords)
+            {
+                for (int i = 0; i + termWords.Length <= words.Length; i++)
+                {
+                    bool match = !removed[i];
+                    for (int j = 0; match && j < termWords.Length; j++)
+                        match = !removed[i + j] && string.Equals(words[i + j], termWords[j], StringComparison.OrdinalIgnoreCase);
+                    if (match)
+                        for (int j = 0; j < termWords.Length; j++)
+                            removed[i + j] = true;
+                }
+            }
+
+            return string.Join(' ', words.Where((_, i) => !removed[i]));
+        }
+
+        public static bool ContainsBlockedTerms(string searchText)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
+                return false;
+
+            string[] words = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            return RemoveBlockedTerms(searchText).Split(' ', StringSplitOptions.RemoveEmptyEntries).Length != words.Length;
+        }
+
+        private static readonly Dictionary<char, string> AccentInjectionMap = new()
+        {
+            { 'a', "àáâä" }, { 'A', "ÀÁÂÄ" },
+            { 'e', "èéêë" }, { 'E', "ÈÉÊË" },
+            { 'i', "ìíîï" }, { 'I', "ÌÍÎÏ" },
+            { 'o', "òóôö" }, { 'O', "ÒÓÔÖ" },
+            { 'u', "ùúûü" }, { 'U', "ÙÚÛÜ" },
+            { 'y', "ýÿ" }, { 'Y', "ÝŸ" },
+            { 'c', "çć" }, { 'C', "ÇĆ" },
+            { 'n', "ñń" }, { 'N', "ÑŃ" },
+            { 's', "śş" }, { 'S', "ŚŞ" },
+        };
+
+        /// <summary>
+        /// Rewrites blocked terms by injecting an accented character so the
+        /// query slips past the Soulseek server filter while still matching
+        /// share paths that use accented spellings. When no accent can be
+        /// injected the blocked term is dropped entirely.
+        /// </summary>
+        public static string RewriteRestrictedTerms(string searchText, int variant = 0)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
+                return string.Empty;
+
+            string[] words = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            string[] normalized = [.. words.Select(NormalizeSpecialCharacters)];
+            bool[] keep = [.. words.Select(_ => true)];
+
+            foreach (string[] termWords in BlockedTermWords)
+                for (int i = 0; i + termWords.Length <= words.Length; i++)
+                {
+                    bool match = true;
+                    for (int j = 0; match && j < termWords.Length; j++)
+                        match = string.Equals(normalized[i + j], termWords[j], StringComparison.OrdinalIgnoreCase);
+                    if (!match)
+                        continue;
+
+                    bool injected = false;
+                    for (int j = 0; j < termWords.Length && !injected; j++)
+                        injected = TryInjectAccent(ref words[i + j], variant);
+
+                    if (!injected)
+                        for (int j = 0; j < termWords.Length; j++)
+                            keep[i + j] = false;
+                }
+
+            return string.Join(' ', words.Where((_, i) => keep[i]));
+        }
+
+        private static bool TryInjectAccent(ref string word, int variant)
+        {
+            for (int c = 0; c < word.Length; c++)
+            {
+                if (AccentInjectionMap.TryGetValue(word[c], out string? variants))
+                {
+                    word = word[..c] + variants[variant % variants.Length] + word[(c + 1)..];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Distinctive track titles usable as search evidence when the artist
+        /// name itself is server-blocked: cleaned, non-blocked, distinct from
+        /// the album title, longest first.
+        /// </summary>
+        public static IEnumerable<string> GetBlockedTermEvidenceTracks(IEnumerable<string> tracks, string? album)
+        {
+            return tracks
+                .Select(CleanEvidenceTitle)
+                .Where(t => t.Length >= 3
+                            && !ContainsBlockedTerms(t)
+                            && !string.Equals(t, album?.Trim(), StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(t => t.Length);
+
+            static string CleanEvidenceTitle(string title)
+            {
+                string cleaned = BracketedContentRegex().Replace(title, " ");
+                cleaned = StripPunctuation(cleaned);
+                return cleaned.Trim();
+            }
+        }
+
         private static readonly char[] PathSeparators = ['\\', '/'];
 
         // Soulseek paths are canonically backslash-separated, but some clients
@@ -179,5 +346,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         [GeneratedRegex(@"^(?:cd|disc|disk|dvd)\s*[-_. ]?\s*\d{1,2}$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
         private static partial Regex DiscFolderRegex();
+
+        [GeneratedRegex(@"[\(\[\{].*?[\)\]\}]", RegexOptions.Compiled)]
+        private static partial Regex BracketedContentRegex();
     }
 }

--- a/src/Sleezer/Notifications/FlareSolverr/FlareDetector.cs
+++ b/src/Sleezer/Notifications/FlareSolverr/FlareDetector.cs
@@ -76,8 +76,10 @@ public static class FlareDetector
         }
         else
         {
-            Logger.Trace("Not a Cloudflare/DDoS-Guard server for {0}", url);
-            return false;
+            // Challenges are often served behind proxies that don't label
+            // themselves Cloudflare — fall through to body inspection instead
+            // of declaring no-challenge on the header alone.
+            Logger.Trace("No Cloudflare/DDoS-Guard server header for {0}, falling back to body inspection", url);
         }
 
         string responseText = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
@@ -90,13 +92,6 @@ public static class FlareDetector
             return false;
         }
 
-        // Check for Cloudflare error codes
-        if (responseText.TrimStart().StartsWith("error code:", StringComparison.OrdinalIgnoreCase))
-        {
-            Logger.Trace("Cloudflare error code detected in content for {0}", url);
-            return true;
-        }
-
         // Check for actual challenge indicators
         string? challengeIndicator = CloudflareChallengeIndicators.FirstOrDefault(indicator =>
             responseText.Contains(indicator, StringComparison.OrdinalIgnoreCase));
@@ -105,6 +100,21 @@ public static class FlareDetector
         {
             Logger.Trace("Challenge indicator '{0}' found in content for {1}", challengeIndicator, url);
             return true;
+        }
+
+        // Check for Cloudflare error codes
+        if (responseText.TrimStart().StartsWith("error code:", StringComparison.OrdinalIgnoreCase))
+        {
+            Logger.Trace("Cloudflare error code detected in content for {0}", url);
+            return true;
+        }
+
+        // Without a Cloudflare server header, only a definitive body indicator
+        // counts — avoids false positives on ordinary 403/503 responses.
+        if (!isCloudflareServer)
+        {
+            Logger.Trace("No definitive challenge indicator and no Cloudflare server header for {0}", url);
+            return false;
         }
 
         // Check for custom Cloudflare configurations (some Dutch torrent sites)

--- a/src/Sleezer/Notifications/FlareSolverr/FlareRecords.cs
+++ b/src/Sleezer/Notifications/FlareSolverr/FlareRecords.cs
@@ -11,7 +11,7 @@ public record FlareCookie(
     [property: JsonPropertyName("value")] string Value,
     [property: JsonPropertyName("domain")] string Domain,
     [property: JsonPropertyName("path")] string Path = "/",
-    [property: JsonPropertyName("expires")] int Expiry = 0,
+    [property: JsonPropertyName("expires")] double Expiry = 0,
     [property: JsonPropertyName("httpOnly")] bool HttpOnly = false,
     [property: JsonPropertyName("secure")] bool Secure = false,
     [property: JsonPropertyName("sameSite")] string? SameSite = null)

--- a/src/Sleezer/Notifications/PlaylistExport/PlaylistExportService.cs
+++ b/src/Sleezer/Notifications/PlaylistExport/PlaylistExportService.cs
@@ -24,10 +24,10 @@ public interface IPlaylistExportService
 }
 
 public sealed partial class PlaylistExportService : IPlaylistExportService,
-    IHandle<ApplicationStartedEvent>,
-    IHandle<ProviderAddedEvent<IImportList>>,
-    IHandle<ProviderUpdatedEvent<IImportList>>,
-    IHandle<ProviderDeletedEvent<IImportList>>
+    IHandleAsync<ApplicationStartedEvent>,
+    IHandleAsync<ProviderAddedEvent<IImportList>>,
+    IHandleAsync<ProviderUpdatedEvent<IImportList>>,
+    IHandleAsync<ProviderDeletedEvent<IImportList>>
 {
     private const string SnapshotKey = "playlistExport.snapshots";
 
@@ -63,11 +63,13 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
         _logger = logger;
     }
 
-    public void Handle(ApplicationStartedEvent message) => RefreshSchema();
-    public void Handle(ProviderAddedEvent<IImportList> message) => RefreshSchema();
-    public void Handle(ProviderUpdatedEvent<IImportList> message) => RefreshSchema();
+    // Async handlers: schema refresh walks providers and (on Windows exe)
+    // could block the synchronous event bus during startup, hanging boot.
+    public Task HandleAsync(ApplicationStartedEvent message) => Task.Run(RefreshSchema);
+    public Task HandleAsync(ProviderAddedEvent<IImportList> message) => Task.Run(RefreshSchema);
+    public Task HandleAsync(ProviderUpdatedEvent<IImportList> message) => Task.Run(RefreshSchema);
 
-    public void Handle(ProviderDeletedEvent<IImportList> message)
+    public Task HandleAsync(ProviderDeletedEvent<IImportList> message)
     {
         Dictionary<int, PlaylistSnapshot> snapshots = GetSnapshots();
 
@@ -92,6 +94,7 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
         }
 
         RefreshSchema();
+        return Task.CompletedTask;
     }
 
     public void RefreshSchema()

--- a/src/Sleezer/Notifications/PlaylistExport/PlaylistExportService.cs
+++ b/src/Sleezer/Notifications/PlaylistExport/PlaylistExportService.cs
@@ -63,13 +63,14 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
         _logger = logger;
     }
 
-    // Async handlers: schema refresh walks providers and (on Windows exe)
-    // could block the synchronous event bus during startup, hanging boot.
-    public Task HandleAsync(ApplicationStartedEvent message) => Task.Run(RefreshSchema);
-    public Task HandleAsync(ProviderAddedEvent<IImportList> message) => Task.Run(RefreshSchema);
-    public Task HandleAsync(ProviderUpdatedEvent<IImportList> message) => Task.Run(RefreshSchema);
+    // IHandleAsync: Lidarr's event bus dispatches these on its async workers
+    // (the interface returns void), so a slow schema refresh can't block the
+    // synchronous startup event path.
+    public void HandleAsync(ApplicationStartedEvent message) => RefreshSchema();
+    public void HandleAsync(ProviderAddedEvent<IImportList> message) => RefreshSchema();
+    public void HandleAsync(ProviderUpdatedEvent<IImportList> message) => RefreshSchema();
 
-    public Task HandleAsync(ProviderDeletedEvent<IImportList> message)
+    public void HandleAsync(ProviderDeletedEvent<IImportList> message)
     {
         Dictionary<int, PlaylistSnapshot> snapshots = GetSnapshots();
 
@@ -94,7 +95,6 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
         }
 
         RefreshSchema();
-        return Task.CompletedTask;
     }
 
     public void RefreshSchema()

--- a/tests/Sleezer.Tests/Sleezer.Tests.csproj
+++ b/tests/Sleezer.Tests/Sleezer.Tests.csproj
@@ -89,6 +89,8 @@
              LinkBase="SourceUnderTest" />
     <Compile Include="..\..\src\Sleezer\Download\Clients\Soulseek\Models\SlskdDownloadDirectory.cs"
              LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Download\Clients\Soulseek\SlskdPathResolver.cs"
+             LinkBase="SourceUnderTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Sleezer.Tests/SlskdUpstreamPortTests.cs
+++ b/tests/Sleezer.Tests/SlskdUpstreamPortTests.cs
@@ -1,0 +1,82 @@
+using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
+using Xunit;
+
+namespace Sleezer.Tests;
+
+// Covers the TypNull/Tubifarry ae3ce28 + d857a0f ports: Soulseek-server
+// blocked-term handling and slskd destination subdirectory resolution.
+public class BlockedTermTests
+{
+    [Theory]
+    [InlineData("Adele 25", true)]
+    [InlineData("Kendrick Lamar DAMN", true)]
+    [InlineData("Radiohead OK Computer", false)]
+    public void ContainsBlockedTerms_detects_server_filtered_terms(string query, bool expected)
+    {
+        Assert.Equal(expected, SlskdTextProcessor.ContainsBlockedTerms(query));
+    }
+
+    [Fact]
+    public void RemoveBlockedTerms_strips_multi_word_terms()
+    {
+        Assert.Equal("DAMN", SlskdTextProcessor.RemoveBlockedTerms("Kendrick Lamar DAMN"));
+    }
+
+    [Fact]
+    public void RewriteRestrictedTerms_injects_accent_that_evades_the_filter()
+    {
+        string rewritten = SlskdTextProcessor.RewriteRestrictedTerms("Adele 25");
+
+        Assert.NotEqual("Adele 25", rewritten);
+        Assert.False(SlskdTextProcessor.ContainsBlockedTerms(rewritten));
+        Assert.EndsWith(" 25", rewritten);
+    }
+
+    [Fact]
+    public void GetBlockedTermEvidenceTracks_prefers_longest_clean_titles()
+    {
+        string[] tracks = ["Hello", "Someone Like You", "25"];
+        List<string> evidence = SlskdTextProcessor.GetBlockedTermEvidenceTracks(tracks, "25").ToList();
+
+        Assert.Equal("Someone Like You", evidence[0]);
+        Assert.DoesNotContain("25", evidence);
+    }
+}
+
+public class SlskdPathResolverTests
+{
+    private static readonly SlskdDestinationConfig DefaultConfig = new("/downloads", null);
+
+    [Fact]
+    public void Default_pattern_resolves_to_source_directory()
+    {
+        string? result = SlskdPathResolver.ResolveSubdirectory(DefaultConfig, "peer", @"@@abc12\Artist\Album\01.flac");
+        Assert.Equal("Album", result);
+    }
+
+    [Fact]
+    public void Custom_pattern_substitutes_tokens()
+    {
+        SlskdDestinationConfig config = new("/downloads", "${SOURCE_USERNAME}/${SOURCE_DIRECTORY}");
+        string? result = SlskdPathResolver.ResolveSubdirectory(config, "peer", @"music\Artist\Album\01.flac");
+        Assert.Equal("peer/Album", result);
+    }
+
+    [Fact]
+    public void Traversal_segments_in_resolved_path_are_rejected()
+    {
+        SlskdDestinationConfig config = new("/downloads", "../${SOURCE_DIRECTORY}");
+        Assert.Null(SlskdPathResolver.ResolveSubdirectory(config, "peer", @"music\Album\01.flac"));
+    }
+
+    [Theory]
+    [InlineData("/downloads", "/downloads/Album", "Album")]
+    [InlineData("/downloads", "/downloads/peer/Album", "peer/Album")]
+    [InlineData("/downloads", "/elsewhere/Album", null)]
+    [InlineData("/downloads", "/downloads", "")]
+    public void MakeRelativeToDownloads_handles_containment(string root, string path, string? expected)
+    {
+        Assert.Equal(expected, SlskdPathResolver.MakeRelativeToDownloads(root, path));
+    }
+}

--- a/tests/Sleezer.Tests/SlskdUpstreamPortTests.cs
+++ b/tests/Sleezer.Tests/SlskdUpstreamPortTests.cs
@@ -30,7 +30,10 @@ public class BlockedTermTests
 
         Assert.NotEqual("Adele 25", rewritten);
         Assert.False(SlskdTextProcessor.ContainsBlockedTerms(rewritten));
-        Assert.EndsWith(" 25", rewritten);
+
+        // The rewrite must PRESERVE the artist term (accent-folded it is the
+        // original query), not delete or replace it.
+        Assert.Equal("Adele 25", SlskdTextProcessor.NormalizeSpecialCharacters(rewritten));
     }
 
     [Fact]
@@ -75,6 +78,8 @@ public class SlskdPathResolverTests
     [InlineData("/downloads", "/downloads/peer/Album", "peer/Album")]
     [InlineData("/downloads", "/elsewhere/Album", null)]
     [InlineData("/downloads", "/downloads", "")]
+    [InlineData("/downloads", "/downloads//../etc", null)]
+    [InlineData("/downloads", "/downloads/a/../../etc", null)]
     public void MakeRelativeToDownloads_handles_containment(string root, string path, string? expected)
     {
         Assert.Equal(expected, SlskdPathResolver.MakeRelativeToDownloads(root, path));


### PR DESCRIPTION
## Why

Follow-up to #57: ports the applicable last-2-months of upstream TypNull/Tubifarry `develop` work into sleezer's slskd integration, adapted around the local divergence #57 introduced (merged-directory grouping, strictness offsets, short-name token matching, path-confinement guards, IndexerPriority-based ranking).

> Stacked on `fix/slskd-search-matching` (#57) — this diff shows only the port work.

## What

### Search & matching (upstream `ae3ce28`)

- **Soulseek-server blocked terms** — the headline upstream discovery: ~23 terms (mostly DMCA-listed artists: Beyoncé, Adele, Beatles, Kendrick Lamar, …) are **silently filtered by the Soulseek server**; any search containing one returns zero results network-wide. Queries are now rewritten with an injected accented character (which the filter misses but accented share paths still match); when no rewrite survives, a new `BlockedTermEvidenceStrategy` searches album + most-distinctive track title with the artist omitted.
- **Track-title evidence matching** — expected track titles ride along in the result request (≤50); when ≥35% appear among a folder's filenames the album match is forced and priority gains up to +400. This is what confirms matches for blocked artists and anonymous folder layouts.
- **Path-tail album matching** — fuzzy album match retried against the last two path components.
- **Wrong-album guards** — folder-derived fallback album names cleaned of share junk (`@user`, dates, GUIDs) and embedded artist names; folders with non-contiguous track numbers get half priority.
- **`Artist - (1994) Album` folder pattern** added (adapted to the ` - ` split rule from #57 so hyphenated artists survive).
- **CalculatePriority rebalance** — queue length × free-slot multiplicative (a 40-deep queue with a nominally "free slot" no longer outranks an empty queue), plus a file-consistency bonus.
- **Source tag detection** — `[WEB]`/`[CD]`/`[Vinyl]`/`[SACD]` from the share path instead of a hardcoded `[WEB]`, so Lidarr's quality parser sees the real source.
- Typed search request body replaces the `dynamic` payload.

*Deliberately not ported:* upstream's `ExtendedDownloadDecisionComparer`/priorization service and its `CleanupReleases` deletion — #57's `ShareInfo.Seeders → CleanupReleases → IndexerPriority` path achieves the ranking with far less surface; also the emoji title decorations and `ShowPriorityInTitle` (sleezer deliberately keeps release titles minimal).

### Download client (upstream `d857a0f`)

- **Batch enqueue endpoint** (`POST /api/v0/transfers/downloads/batches`) with graceful fallback to the legacy endpoint on older slskd. Surfaces **per-file enqueue failures** (including user-offline detection) instead of silently "succeeding"; all-failed enqueues now fail the grab immediately.
- **Multi-disc via batch destination** — multi-disc grabs pass an album-named `destination`, so slskd itself lands every disc in one folder; #57's post-download merge remains as the legacy-endpoint fallback.
- **`SlskdPathResolver`** — resolves the local subfolder under non-default `transfers.download.destination.subdirectory` patterns, and converts `DownloadDirectoryComplete` `localDirectoryName` (ground truth) into the item's confirmed output path. Fixes failed imports on slskd setups with custom subdirectory patterns.
- **Local file deletion fix** — `RemoveItemFilesAsync` deleted by concatenating the *remote* path onto the downloads root, which never matched a real file; now deletes basename inside the item's resolved output folder.

### Small fixes

- **FlareSolverr detector** (upstream `a8ab7d7`): challenges behind proxies that don't send a Cloudflare `Server` header are now caught by body inspection; conversely, non-CF servers with no definitive indicator no longer count (fewer false positives). `FlareCookie.expires` is now `double` — FlareSolverr returns fractional epoch values that previously threw on deserialization and killed cookie handling.
- **PlaylistExport** (upstream `3d9adc4`): schema refresh handlers moved to `IHandleAsync` so a slow provider walk can't block the synchronous event bus during startup.

*Deferred:* upstream `ac73ce4` (T2Tunes new GraphQL-shaped API) — porting it before the T2Tunes server container updates would break against the current server exactly the way not porting breaks against the new one.

## Testing

- `dotnet build Sleezer.sln -c Release -p:NuGetAudit=false` — clean.
- `dotnet test tests/Sleezer.Tests` — all passing, with new coverage for blocked-term detection/rewrite/evidence ordering and `SlskdPathResolver` (default/custom/traversal patterns, downloads-relative conversion).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soulseek downloads now support batch enqueueing with configurable destination subfolders, improving multi-disc placement and folder/subdirectory tracking.
  * Soulseek album titles can reflect the detected media source instead of a fixed label.
  * Soulseek search can rewrite restricted terms and fall back using track-title evidence.

* **Bug Fixes**
  * Improved Soulseek album matching, transfer ownership/completion detection, and corrected local file removal for Soulseek downloads.
  * Refined challenge detection for flare notifications and improved cookie expiry parsing; playlist export refresh updates now run asynchronously.

* **Tests**
  * Added coverage for blocked-term handling and Soulseek subdirectory/path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->