### PR TITLE
fix(slskd): retry downloadIds, remix guard, in-flight search cancel

### DIFF
--- a/src/Sleezer/Core/PostProcessing/PreImportTagger.cs
+++ b/src/Sleezer/Core/PostProcessing/PreImportTagger.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.MediaFiles.TrackImport.Identification;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
 
 namespace NzbDrone.Plugin.Sleezer.Core.PostProcessing;
 
@@ -114,6 +115,19 @@ public class PreImportTagger : IPreImportTagger
         {
             _logger.Debug("Pre-import tag: no audio files found under {Folder}", folderPath);
             return new TaggingResult(0, 0, 0);
+        }
+
+        // A remix release is a different album, and writing the target album's
+        // tags onto remix audio launders it straight past Lidarr's import
+        // matching (verified live 2026-07-21: a "Marc Stout & Scott Svejda
+        // remix" download was tagged as the plain single and imported over the
+        // original). Fail closed: leave the raw tags for Lidarr to judge.
+        string folderLeaf = Path.GetFileName(folderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (SlskdTextProcessor.RemixSignaturesConflict(album.Title, folderLeaf))
+        {
+            _logger.Info("Pre-import tag: remix qualifier mismatch between album '{Album}' and folder '{Folder}' — skipping tagging for {FileCount} files in \"{SourceId}\"",
+                album.Title, folderLeaf, audioFiles.Count, sourceId);
+            return new TaggingResult(0, audioFiles.Count, 0);
         }
 
         _logger.Debug("Pre-import tag: identifying {FileCount} audio file(s) for {Album} by {Artist} (sourceId={SourceId})",

--- a/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/Models/SlskdDownloadItem.cs
@@ -2,6 +2,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.History;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using System.Text.Json;
@@ -191,6 +192,48 @@ public class SlskdDownloadItem
         string combined = string.Join("|", filenames.Order());
         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(combined);
         return BitConverter.ToString(System.Security.Cryptography.MD5.HashData(bytes)).Replace("-", "").ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Picks the downloadId for a new grab. Lidarr's tracked-download cache is
+    /// keyed by downloadId and keeps returning the cached object once its state
+    /// leaves Downloading, so a re-grab after a download failure must NOT reuse
+    /// the failed attempt's id — the completed retry would be silently ignored
+    /// and never imported. Walks -r2..-r9 until it finds an id whose latest
+    /// download-history event is not DownloadFailed.
+    /// </summary>
+    public static string ResolveRetryId(string baseId, Func<string, DownloadHistoryEventType?> latestEventTypeFor)
+    {
+        string id = baseId;
+        for (int attempt = 2; attempt <= 9; attempt++)
+        {
+            if (latestEventTypeFor(id) != DownloadHistoryEventType.DownloadFailed)
+                return id;
+
+            id = $"{baseId}-r{attempt}";
+        }
+
+        return id;
+    }
+
+    /// <summary>
+    /// Strips the "-r&lt;n&gt;" suffix a retry grab gets (see ResolveRetryId),
+    /// recovering the stable content hash shared by every attempt at the same
+    /// release.
+    /// </summary>
+    public static string StripRetrySuffix(string id)
+    {
+        int marker = id.LastIndexOf("-r", StringComparison.Ordinal);
+        if (marker <= 0 || marker + 2 >= id.Length)
+            return id;
+
+        for (int i = marker + 2; i < id.Length; i++)
+        {
+            if (!char.IsAsciiDigit(id[i]))
+                return id;
+        }
+
+        return id[..marker];
     }
 
     private void CompareFileStates(SlskdDownloadDirectory? newDirectory)

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -572,16 +572,13 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             i.OwnsFile(probeFile));
     }
 
-    // Transfers slskd reports after a Lidarr restart have no in-memory item to
-    // map to. The per-directory content hash finds plain single-folder grabs,
-    // but a retry grab lives under an -rN suffix and a multi-disc grab hashes
-    // every disc — for those, walk recent Soulseek grabs newest-first and match
-    // by enqueued-file membership, the same rule the live mapping uses. Without
-    // this, restart-orphaned downloads sat invisible to Lidarr until re-grabbed.
+    // Restart re-attach: -rN retry and multi-disc grab ids never equal the
+    // per-directory hash, so fall back to file-membership over recent grabs.
     private DownloadHistory? FindGrabOwningDirectory(string hash, SlskdDownloadDirectory dir)
     {
         DownloadHistory? direct = _downloadHistoryService.GetLatestGrab(hash);
-        if (direct != null)
+        if (direct?.Release != null &&
+            string.Equals(direct.Protocol, nameof(SoulseekDownloadProtocol), StringComparison.OrdinalIgnoreCase))
             return direct;
 
         string? probeFile = dir.Files?.FirstOrDefault()?.Filename;

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -161,6 +161,22 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         {
             ResolvedAlbum = remoteAlbum.Albums?.FirstOrDefault()
         };
+
+        // Lidarr's TrackedDownloadService caches tracked downloads by downloadId
+        // and keeps returning the cached object once its state leaves Downloading.
+        // A re-grab of a failed release reuses the same stable content hash, hits
+        // the cached DownloadFailed entry, and a completed retry is then silently
+        // never imported (verified live 2026-07-21: grab → source fails → re-grab
+        // → download completes → no import until Lidarr restarts). Suffix retries
+        // so each attempt tracks under a fresh id; transfers still map back by
+        // enqueued-file membership regardless of the id.
+        string retryId = SlskdDownloadItem.ResolveRetryId(item.ID, id => _downloadHistoryService.GetLatestDownloadHistoryItem(id)?.EventType);
+        if (retryId != item.ID)
+        {
+            _logger.Debug("Release {Id} has failed download history; tracking this attempt as {RetryId}", item.ID, retryId);
+            item.ID = retryId;
+        }
+
         _logger.Trace("Download initiated: {Title} | Files: {FileCount}", remoteAlbum.Release.Title, item.FileData.Count);
 
         try

--- a/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
+++ b/src/Sleezer/Download/Clients/Soulseek/SlskdDownloadManager.cs
@@ -4,11 +4,13 @@ using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.Download.History;
+using NzbDrone.Core.History;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Music;
 using NzbDrone.Plugin.Sleezer.Core.Model;
 using NzbDrone.Plugin.Sleezer.Core.PostProcessing;
@@ -40,6 +42,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
 
     private readonly ISlskdApiClient _apiClient;
     private readonly IDownloadHistoryService _downloadHistoryService;
+    private readonly IHistoryService _historyService;
     private readonly ISlskdItemsParser _slskdItemsParser;
     private readonly IRemotePathMappingService _remotePathMappingService;
     private readonly IDiskProvider _diskProvider;
@@ -64,6 +67,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
     public SlskdDownloadManager(
         ISlskdApiClient apiClient,
         IDownloadHistoryService downloadHistoryService,
+        IHistoryService historyService,
         ISlskdItemsParser slskdItemsParser,
         IRemotePathMappingService remotePathMappingService,
         IDiskProvider diskProvider,
@@ -76,6 +80,7 @@ public class SlskdDownloadManager : ISlskdDownloadManager
     {
         _apiClient = apiClient;
         _downloadHistoryService = downloadHistoryService;
+        _historyService = historyService;
         _slskdItemsParser = slskdItemsParser;
         _remotePathMappingService = remotePathMappingService;
         _diskProvider = diskProvider;
@@ -500,12 +505,23 @@ public class SlskdDownloadManager : ISlskdDownloadManager
             if (item == null)
             {
                 _logger.Trace("[def={DefinitionId}] Unknown item {Hash}: checking history", definitionId, hash);
-                DownloadHistory? history = _downloadHistoryService.GetLatestGrab(hash);
+                DownloadHistory? history = FindGrabOwningDirectory(hash, dir);
 
                 if (history != null)
-                    item = new SlskdDownloadItem(history.Release);
+                {
+                    item = new SlskdDownloadItem(history.Release)
+                    {
+                        // The grab's id, not the recomputed content hash: a
+                        // retry grab carries an -rN suffix and a multi-disc
+                        // grab hashes ALL discs — Lidarr tracks both under
+                        // the id it was handed at grab time.
+                        ID = history.DownloadId
+                    };
+                }
                 else if (settings.Inclusive)
+                {
                     item = new SlskdDownloadItem(CreateReleaseInfoFromDirectory(userTransfers.Username, dir));
+                }
 
                 if (item == null)
                     continue;
@@ -554,6 +570,48 @@ public class SlskdDownloadManager : ISlskdDownloadManager
         return GetItemsForDef(definitionId).FirstOrDefault(i =>
             (i.Username == null || string.Equals(i.Username, username, StringComparison.OrdinalIgnoreCase)) &&
             i.OwnsFile(probeFile));
+    }
+
+    // Transfers slskd reports after a Lidarr restart have no in-memory item to
+    // map to. The per-directory content hash finds plain single-folder grabs,
+    // but a retry grab lives under an -rN suffix and a multi-disc grab hashes
+    // every disc — for those, walk recent Soulseek grabs newest-first and match
+    // by enqueued-file membership, the same rule the live mapping uses. Without
+    // this, restart-orphaned downloads sat invisible to Lidarr until re-grabbed.
+    private DownloadHistory? FindGrabOwningDirectory(string hash, SlskdDownloadDirectory dir)
+    {
+        DownloadHistory? direct = _downloadHistoryService.GetLatestGrab(hash);
+        if (direct != null)
+            return direct;
+
+        string? probeFile = dir.Files?.FirstOrDefault()?.Filename;
+        if (string.IsNullOrEmpty(probeFile))
+            return null;
+
+        IEnumerable<string> recentGrabIds = _historyService.Since(DateTime.UtcNow.AddDays(-14), EntityHistoryEventType.Grabbed)
+            .OrderByDescending(h => h.Date)
+            .Select(h => h.DownloadId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string downloadId in recentGrabIds)
+        {
+            DownloadHistory? grab = _downloadHistoryService.GetLatestGrab(downloadId);
+            if (grab?.Release == null || !string.Equals(grab.Protocol, nameof(SoulseekDownloadProtocol), StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                if (new SlskdDownloadItem(grab.Release).OwnsFile(probeFile))
+                    return grab;
+            }
+            catch (Exception ex)
+            {
+                _logger.Trace(ex, "Skipping grab {DownloadId} while probing ownership of {File}", downloadId, probeFile);
+            }
+        }
+
+        return null;
     }
 
     private static string SanitizeFolderName(string name)

--- a/src/Sleezer/Indexers/Soulseek/SlskdIndexerParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdIndexerParser.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using NzbDrone.Plugin.Sleezer.Core.Model;
 using NzbDrone.Plugin.Sleezer.Core.Utilities;
 using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
+using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
 
 namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 {
@@ -34,6 +35,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         private readonly object _rateLimitLock = new();
         private DateTime _rateLimitCacheTimestamp = DateTime.MinValue;
         private HashSet<string> _rateLimitedUsersCache = new(StringComparer.OrdinalIgnoreCase);
+        private DateTime _failedIdCacheTimestamp = DateTime.MinValue;
+        private HashSet<string> _failedIdCache = new(StringComparer.OrdinalIgnoreCase);
 
         private SlskdSettings Settings => _indexer.Settings;
 
@@ -67,10 +70,12 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 SlskdSearchData searchTextData = SlskdSearchData.FromJson(indexerResponse.HttpRequest.ContentSummary);
                 HashSet<string>? ignoredUsers = GetIgnoredUsers(Settings.IgnoreListPath);
                 HashSet<string> rateLimitedUsers = GetRateLimitedUsers();
+                HashSet<string> recentlyFailedIds = GetRecentlyFailedDownloadIds();
 
                 int totalResponses = searchResponse.Responses?.Count() ?? 0;
                 int droppedIgnored = 0;
                 int droppedRateLimited = 0;
+                int droppedRecentlyFailed = 0;
 
                 foreach (SlskdFolderData response in searchResponse.Responses ?? Enumerable.Empty<SlskdFolderData>())
                 {
@@ -132,13 +137,35 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                             }
                         }
 
+                        // Same content hash the download client will assign this
+                        // release: skip sources that already failed recently. The
+                        // blocklist rows Lidarr writes for Soulseek grabs carry no
+                        // protocol, so its own Blocklist spec never filters them
+                        // and a dead share re-surfaces at the same rank on the
+                        // very next search (verified live 2026-07-21: the same
+                        // "File not shared" release was re-grabbed twice within
+                        // a minute).
+                        // Interactive searches stay unfiltered: a manual re-grab
+                        // of a failed source is deliberate (and imports fine now
+                        // that retries get their own downloadId).
+                        if (!searchTextData.Interactive)
+                        {
+                            string prospectiveId = SlskdDownloadItem.GetStableMD5Id(finalGroup.Select(f => f.Filename));
+                            if (recentlyFailedIds.Contains(prospectiveId))
+                            {
+                                droppedRecentlyFailed++;
+                                _logger.Trace("Filtered (failed within 24h): {Directory}", directoryGroup.Key);
+                                continue;
+                            }
+                        }
+
                         AlbumData albumData = _itemsParser.CreateAlbumData(searchResponse.Id, finalGroup, searchTextData, folderData, Settings, searchTextData.TrackCount);
                         albumDatas.Add(albumData);
                     }
                 }
 
-                _logger.Debug("Slskd parse: {Total} response(s), {Albums} album(s) emitted, dropped {Ignored} ignored-user / {RateLimited} rate-limited",
-                    totalResponses, albumDatas.Count, droppedIgnored, droppedRateLimited);
+                _logger.Debug("Slskd parse: {Total} response(s), {Albums} album(s) emitted, dropped {Ignored} ignored-user / {RateLimited} rate-limited / {RecentlyFailed} recently-failed",
+                    totalResponses, albumDatas.Count, droppedIgnored, droppedRateLimited, droppedRecentlyFailed);
 
                 RemoveSearch(searchResponse.Id, albumDatas.Count != 0 && searchTextData.Interactive);
             }
@@ -264,6 +291,30 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 _rateLimitedUsersCache = blocked;
                 _rateLimitCacheTimestamp = DateTime.UtcNow;
                 return blocked;
+            }
+        }
+
+        private HashSet<string> GetRecentlyFailedDownloadIds()
+        {
+            lock (_rateLimitLock)
+            {
+                if (DateTime.UtcNow - _failedIdCacheTimestamp < TimeSpan.FromSeconds(15))
+                    return _failedIdCache;
+
+                HashSet<string> failed = new(StringComparer.OrdinalIgnoreCase);
+                foreach (EntityHistory history in _historyService.Since(DateTime.UtcNow.AddHours(-24), EntityHistoryEventType.DownloadFailed))
+                {
+                    if (string.IsNullOrWhiteSpace(history.DownloadId))
+                        continue;
+
+                    // Retry grabs record their failure under the suffixed id;
+                    // fold it back so the base release is skipped too.
+                    failed.Add(SlskdDownloadItem.StripRetrySuffix(history.DownloadId));
+                }
+
+                _failedIdCache = failed;
+                _failedIdCacheTimestamp = DateTime.UtcNow;
+                return failed;
             }
         }
 

--- a/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdItemsParser.cs
@@ -130,6 +130,21 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 matchedSearchCriteria = isAlbumMatch;
             }
 
+            // Runs after every album-match route including track evidence: a
+            // remix single's filenames CONTAIN the base title, so evidence
+            // would otherwise force the false match right back.
+            if (isAlbumMatch && !string.IsNullOrEmpty(searchData.Album))
+            {
+                string[] pathComponents = SplitPathIntoComponents(directory.Key);
+                string candidateLeaf = pathComponents.Length > 0 ? pathComponents[^1] : directory.Key;
+                if (SlskdTextProcessor.RemixSignaturesConflict(searchData.Album, candidateLeaf))
+                {
+                    _logger.Trace("Remix qualifier mismatch: search '{Album}' vs folder '{Folder}'", searchData.Album, candidateLeaf);
+                    isAlbumMatch = false;
+                    matchedSearchCriteria = false;
+                }
+            }
+
             _logger.Debug("Match results - Artist: {ArtistMatch}, Album: {AlbumMatch}, TrackEvidence: {Evidence:P0}", isArtistMatch, isAlbumMatch, trackEvidence);
 
             // Determine final values for artist, album, year

--- a/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -256,7 +256,12 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 // DbUpdateConcurrencyException — verified live 2026-07-21, with
                 // the search's results silently lost). Cancel first so the record
                 // reaches a terminal state and the later delete is clean.
-                if (finalState.StartsWith("InProgress", StringComparison.OrdinalIgnoreCase))
+                // "Unknown" (a run of failed polls) says nothing about whether
+                // the search still runs — if slskd was only transiently
+                // unreachable, skipping the cancel here reopens the same
+                // delete-in-flight race. A cancel against a truly vanished
+                // search is a harmless 404.
+                if (finalState.StartsWith("InProgress", StringComparison.OrdinalIgnoreCase) || finalState == "Unknown")
                     await CancelInFlightSearchAsync(searchId);
             }
             finally

--- a/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -246,12 +246,51 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             try
             {
                 await ExecuteCreateSearchWithRetryAsync(searchRequest, searchId);
-                await WaitOnSearchCompletionAsync(searchId, TimeSpan.FromSeconds(Settings.TimeoutInSeconds));
+                string finalState = await WaitOnSearchCompletionAsync(searchId, TimeSpan.FromSeconds(Settings.TimeoutInSeconds));
+
+                // slskd's SearchTimeout is an INACTIVITY window, so a search with
+                // a steady trickle of responses can outlive our client-side wait.
+                // The parser deletes the search record as soon as it has read the
+                // results, and deleting an in-flight search makes slskd's own
+                // finalize write hit a vanished row ("Failed to finalize search",
+                // DbUpdateConcurrencyException — verified live 2026-07-21, with
+                // the search's results silently lost). Cancel first so the record
+                // reaches a terminal state and the later delete is clean.
+                if (finalState.StartsWith("InProgress", StringComparison.OrdinalIgnoreCase))
+                    await CancelInFlightSearchAsync(searchId);
             }
             finally
             {
                 gate.Release();
             }
+        }
+
+        private async Task CancelInFlightSearchAsync(string searchId)
+        {
+            try
+            {
+                HttpRequest cancelRequest = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches/{searchId}")
+                    .SetHeader("X-API-KEY", Settings.ApiKey)
+                    .Build();
+                cancelRequest.Method = HttpMethod.Put;
+                await _client.ExecuteAsync(cancelRequest);
+            }
+            catch (HttpException ex)
+            {
+                _logger.Debug(ex, "Cancel request for in-flight search {SearchId} failed", searchId);
+                return;
+            }
+
+            for (int i = 0; i < 6; i++)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                JsonNode? searchStatus = await GetSearchResultsAsync(searchId);
+                string state = searchStatus?["state"]?.GetValue<string>() ?? "Unknown";
+                if (!state.StartsWith("InProgress", StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
+
+            _logger.Debug("Search {SearchId} still in progress 6s after cancel; proceeding anyway", searchId);
         }
 
         // Even with the gate held, a third party may be hitting the same slskd (e.g. the user has the slskd
@@ -319,12 +358,13 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
             return request;
         }
 
-        private async Task WaitOnSearchCompletionAsync(string searchId, TimeSpan timeout)
+        private async Task<string> WaitOnSearchCompletionAsync(string searchId, TimeSpan timeout)
         {
             DateTime startTime = DateTime.UtcNow.AddSeconds(2);
             string state = "InProgress";
             int totalFilesFound = 0;
             bool hasTimedOut = false;
+            int consecutiveFailedPolls = 0;
             DateTime timeoutEndTime = DateTime.UtcNow;
 
             while (state == "InProgress")
@@ -343,6 +383,19 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
                 JsonNode? searchStatus = await GetSearchResultsAsync(searchId);
 
+                // A single failed poll is a transient worth riding out, but a
+                // run of them means the search record is gone — spinning on
+                // "InProgress" for the whole grace window just burns the gate.
+                if (searchStatus == null)
+                {
+                    if (++consecutiveFailedPolls >= 3)
+                        return "Unknown";
+                }
+                else
+                {
+                    consecutiveFailedPolls = 0;
+                }
+
                 state = searchStatus?["state"]?.GetValue<string>() ?? "InProgress";
                 int fileCount = searchStatus?["fileCount"]?.GetValue<int>() ?? 0;
 
@@ -356,6 +409,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 if (state != "InProgress")
                     break;
             }
+
+            return state;
         }
 
         private async Task<JsonNode?> GetSearchResultsAsync(string searchId)

--- a/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using FuzzySharp;
 
 namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 {
@@ -329,6 +330,63 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
                 : directory;
         }
 
+        /// <summary>
+        /// Extracts the remix qualifier from a title: the remixer text when one
+        /// is named ("Never Say Never (Colyn Remix)" → "colyn"), an empty string
+        /// when the title is a generic remix release ("Lets Get Lost Remixes"),
+        /// or null when the title has no remix qualifier at all. Edition
+        /// qualifiers ("Deluxe Edition", "Remastered") are NOT remix qualifiers —
+        /// the word boundary in the keyword regex keeps "edit" from matching
+        /// "Edition".
+        /// </summary>
+        public static string? ExtractRemixSignature(string? title)
+        {
+            if (string.IsNullOrWhiteSpace(title) || !RemixKeywordRegex().IsMatch(title))
+                return null;
+
+            foreach (Match bracket in BracketedContentRegex().Matches(title))
+            {
+                string inner = bracket.Value[1..^1];
+                if (RemixKeywordRegex().IsMatch(inner))
+                    return NormalizeRemixerText(RemixKeywordRegex().Replace(inner, " "));
+            }
+
+            int dash = title.LastIndexOf(" - ", StringComparison.Ordinal);
+            if (dash >= 0)
+            {
+                string tail = title[(dash + 3)..];
+                if (RemixKeywordRegex().IsMatch(tail))
+                    return NormalizeRemixerText(RemixKeywordRegex().Replace(tail, " "));
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// A remix qualifier marks a DIFFERENT release, not a variant of the same
+        /// one: "Never Say Never" must never match "Never Say Never (Colyn Remix)"
+        /// (PartialRatio scores that pair 100), and a search FOR a remix must not
+        /// settle for the original. Two named remixers conflict unless they agree.
+        /// A generic qualifier on both sides, or generic vs named, is allowed.
+        /// </summary>
+        public static bool RemixSignaturesConflict(string? searchAlbum, string? candidateName)
+        {
+            string? searchSignature = ExtractRemixSignature(searchAlbum);
+            string? candidateSignature = ExtractRemixSignature(candidateName);
+
+            if (searchSignature == null && candidateSignature == null)
+                return false;
+            if (searchSignature == null || candidateSignature == null)
+                return true;
+            if (searchSignature.Length == 0 || candidateSignature.Length == 0)
+                return false;
+
+            return Fuzz.TokenSetRatio(searchSignature, candidateSignature) < 60;
+        }
+
+        private static string NormalizeRemixerText(string text) =>
+            StripPunctuation(text).Trim().ToLowerInvariant();
+
         public static HashSet<string> ParseListContent(string content)
         {
             if (string.IsNullOrWhiteSpace(content))
@@ -349,5 +407,8 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
 
         [GeneratedRegex(@"[\(\[\{].*?[\)\]\}]", RegexOptions.Compiled)]
         private static partial Regex BracketedContentRegex();
+
+        [GeneratedRegex(@"\b(remix(es)?|rmx|re-?work(ed)?|bootleg|vip|flip|edit)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        private static partial Regex RemixKeywordRegex();
     }
 }

--- a/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
+++ b/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
@@ -1,0 +1,99 @@
+using NzbDrone.Core.Download.History;
+using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
+using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
+using Xunit;
+
+namespace Sleezer.Tests;
+
+// Covers the follow-up fixes from the 2026-07-21 live verification of v1.8.0:
+// remix qualifiers falsely matching their originals, and failed re-grabs
+// reusing a downloadId that Lidarr's tracked-download cache has already
+// poisoned (completed retries were never imported).
+public class RemixSignatureTests
+{
+    [Theory]
+    [InlineData("Never Say Never", null)]
+    [InlineData("Never Say Never (Colyn Remix)", "colyn")]
+    [InlineData("Never Say Never - Colyn Remix", "colyn")]
+    [InlineData("Lethal Industry (Richard Durand Remixes)", "richard durand")]
+    [InlineData("Lets Get Lost Remixes", "")]                        // generic: keyword outside brackets
+    [InlineData("OK Computer (Deluxe Edition)", null)]               // \bedit\b must not match "Edition"
+    [InlineData("Nevermind (Remastered)", null)]
+    [InlineData("Love Who You Love (Radio Edit)", "radio")]
+    [InlineData("Album (VIP)", "")]
+    [InlineData("Album (2014) [FLAC]", null)]
+    public void ExtractRemixSignature_identifies_remix_qualifiers(string title, string? expected)
+    {
+        Assert.Equal(expected, SlskdTextProcessor.ExtractRemixSignature(title));
+    }
+
+    [Theory]
+    [InlineData("Never Say Never", @"Armin van Buuren - Never Say Never (Colyn Remix)", true)]
+    [InlineData("Never Say Never (Colyn Remix)", @"Armin van Buuren - Never Say Never", true)]
+    [InlineData("Never Say Never (Colyn Remix)", @"Never Say Never (Colyn Remix)", false)]
+    [InlineData("Never Say Never (Colyn Remix)", @"Never Say Never (KIKI Remix)", true)]
+    [InlineData("Never Say Never", @"Armin van Buuren - Never Say Never", false)]
+    [InlineData("Lets Get Lost Remixes", @"G-Eazy - Lets Get Lost Remixes", false)]
+    [InlineData("Lets Get Lost Remixes", @"G-Eazy - Lets Get Lost (Remixes)", false)]
+    [InlineData("Minutes to Midnight", @"Linkin Park - Minutes To Midnight (Explicit)", false)]
+    [InlineData("When Its Dark Out", @"When It's Dark Out (deluxe edition)", false)]
+    [InlineData("Me, Myself & I", "G‐Eazy - Single - 2016 - Me Myself and I Marc Stout and Scott Svejda remix", true)]
+    public void RemixSignaturesConflict_separates_remixes_from_originals(string searchAlbum, string folder, bool expected)
+    {
+        Assert.Equal(expected, SlskdTextProcessor.RemixSignaturesConflict(searchAlbum, folder));
+    }
+}
+
+public class RetryDownloadIdTests
+{
+    [Fact]
+    public void ResolveRetryId_keeps_base_id_without_failed_history()
+    {
+        string id = SlskdDownloadItem.ResolveRetryId("abc123", _ => null);
+        Assert.Equal("abc123", id);
+    }
+
+    [Fact]
+    public void ResolveRetryId_keeps_base_id_when_latest_event_is_a_grab()
+    {
+        string id = SlskdDownloadItem.ResolveRetryId("abc123", _ => DownloadHistoryEventType.DownloadGrabbed);
+        Assert.Equal("abc123", id);
+    }
+
+    [Fact]
+    public void ResolveRetryId_suffixes_after_a_failure()
+    {
+        string id = SlskdDownloadItem.ResolveRetryId(
+            "abc123",
+            queried => queried == "abc123" ? DownloadHistoryEventType.DownloadFailed : null);
+        Assert.Equal("abc123-r2", id);
+    }
+
+    [Fact]
+    public void ResolveRetryId_walks_past_failed_retries()
+    {
+        string id = SlskdDownloadItem.ResolveRetryId(
+            "abc123",
+            queried => queried is "abc123" or "abc123-r2" ? DownloadHistoryEventType.DownloadFailed : null);
+        Assert.Equal("abc123-r3", id);
+    }
+
+    [Fact]
+    public void ResolveRetryId_caps_the_suffix()
+    {
+        string id = SlskdDownloadItem.ResolveRetryId("abc123", _ => DownloadHistoryEventType.DownloadFailed);
+        Assert.Equal("abc123-r9", id);
+    }
+
+    [Theory]
+    [InlineData("abc123-r2", "abc123")]
+    [InlineData("abc123-r9", "abc123")]
+    [InlineData("abc123", "abc123")]
+    [InlineData("abc-rock", "abc-rock")]      // non-numeric tail is not a retry suffix
+    [InlineData("abc123-r", "abc123-r")]
+    public void StripRetrySuffix_recovers_the_content_hash(string input, string expected)
+    {
+        Assert.Equal(expected, SlskdDownloadItem.StripRetrySuffix(input));
+    }
+}


### PR DESCRIPTION
Fixes for four defects found while debugging v1.8.0 against live slskd/Lidarr logs on 2026-07-21.

## Failed re-grabs never import (stuck completed downloads)

Lidarr's `TrackedDownloadService` caches tracked downloads by downloadId and returns the cached object once its state leaves `Downloading`. Our downloadId is a stable content hash, so this sequence poisons it permanently:

1. grab → source fails ("File not shared" / remote cancel) → `downloadFailed` recorded
2. next search re-picks the same or an overlapping release → same downloadId
3. retry download **completes** → Lidarr returns the cached `DownloadFailed` object → never imports, silently drops from queue

Observed live three-for-three: `scared`, `I Luv U`, and `solo` singles all completed on disk at 21:02–21:04 and sat unimported (recoverable only by restarting Lidarr, which clears the cache).

Fix: `ResolveRetryId` suffixes the id (`-r2`, `-r3`, …) when the base id's latest download-history event is `DownloadFailed`, so each retry tracks under a fresh id. Transfer mapping is unaffected (items map back by enqueued-file membership, not id).

## Restart-orphaned downloads stay invisible

Re-attach after a Lidarr restart only worked when the per-directory content hash matched a grab — which retry (`-rN`) grabs and multi-disc grabs never satisfy, leaving completed downloads sitting in slskd invisible to Lidarr until a wasteful re-grab (the multi-disc restart limitation noted in #57).

Fix: unknown transfers now also walk recent Soulseek grabs newest-first and match by enqueued-file membership, then track under the grab's own downloadId, so Lidarr's tracked download picks the item straight back up. slskd can't help here — `externalId` is only used for destination templating and is never echoed back on the transfers API.

## Dead releases re-surface immediately (blocklist never matches)

The blocklist rows Lidarr writes for Soulseek grabs carry no protocol, so its Blocklist specification never filters them, and a dead share re-surfaces at the same rank on the very next search — observed live: the same "File not shared" release grabbed twice within a minute, plus a third source failure, for one album in one search session.

Fix: the parser now skips releases whose prospective content hash has a `DownloadFailed` event in the last 24 h (suffixed retry ids fold back to the base hash). Time-boxed so transiently-failing sources become eligible again.

## In-flight searches deleted mid-run (silent zero results)

slskd's `SearchTimeout` is an *inactivity* window, so a search with a steady trickle of responses outlives our client-side wait. The parser then deletes the search record while slskd is still running it, slskd's finalize write hits a vanished row (`DbUpdateConcurrencyException`, "Failed to execute/finalize search"), and the tier returns a clean zero. Observed live twice (21:58 and 23:11–23:12, the latter against a healthy single-instance slskd).

Fix: when the wait gives up while the search is still `InProgress`, issue slskd's cancel (`PUT /api/v0/searches/{id}`) and poll briefly for a terminal state before releasing the gate, so the later delete hits a finalized record. Also: three consecutive failed polls now abandon the wait instead of reading as "still in progress" for the whole grace window.

## Remix qualifiers falsely match their originals

`PartialRatio("Never Say Never", "Never Say Never (Colyn Remix)")` scores 100, and track-title evidence agrees (remix filenames contain the base title), so remix releases matched plain-album searches and vice versa — then die at import under the wrong album.

Verified live twice over: tonight's `Me, Myself & I` (2015 single) search grabbed the folder `G‐Eazy - Single - 2016 - Me Myself and I Marc Stout and Scott Svejda remix`, the release title got stamped with the *searched* album name, the pre-import tagger wrote the original's tags onto the remix audio (`tagged=1`), and Lidarr imported it over the original — replacing a file that was itself the same remix from a previous occurrence. Lidarr core does the same for torrent releases (a `(Colyn Remix) [Remix]` torrent grabbed for the plain "Never Say Never" single), which a plugin can't fix — but the slskd matcher and tagger are ours.

Fix, two layers:
- `RemixSignaturesConflict` extracts the remix qualifier from both sides (bracketed or dash-tail `remix/rmx/rework/bootleg/vip/flip/edit`, word-bounded so "Edition"/"Remastered" never trip it). One-sided qualifier → no match; two named remixers must agree. Applied in `CreateAlbumData` after every album-match route including track evidence.
- `PreImportTagger` fails closed on the same check (folder level only, so deluxe albums with bonus remix *tracks* are untouched): remix folder for a plain album target → leave the raw tags for Lidarr to judge instead of laundering the file past import matching.

## Tests

`SlskdLiveAuditFollowupTests`: remix-signature extraction/conflict matrix, retry-id resolution (no history / grab / single failure / chained failures / cap), suffix stripping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced remix handling to avoid importing or matching the wrong remix releases.
  * Soulseek downloads now better recover after restarts and correctly associate retry attempts.
  * Recently failed sources are temporarily excluded from non-interactive searches to reduce repeat issues.
  * Searches that hang or remain incomplete are automatically cancelled.
* **Bug Fixes**
  * Reduced incorrect album matching caused by remix filename/qualifier confusion.
  * Improved stability when search results are slow or temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->