### PR TITLE
feat(tagging): title-driven fallback for singles pulled from album shares

### DIFF
--- a/src/Sleezer/Core/PostProcessing/PreImportTagger.cs
+++ b/src/Sleezer/Core/PostProcessing/PreImportTagger.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using FuzzySharp;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Datastore;
@@ -244,9 +245,85 @@ public class PreImportTagger : IPreImportTagger
             }
         }
 
+        // Album-level identification cannot pass for a single/EP pulled out of
+        // an album share — the file's album tag names the share's album. When
+        // everything above failed, fall back to per-track title matching
+        // against the target release (remix/variant qualifiers still conflict).
+        if (tagged == 0 && IsTitleFallbackEligible(album))
+        {
+            (int titleTagged, int titleErrored) = TryTitleDrivenTagging(localTracks, album, albumRelease, stripFeaturedArtists, sourceId, ct);
+            if (titleTagged > 0)
+            {
+                tagged += titleTagged;
+                skipped = Math.Max(0, skipped - titleTagged);
+            }
+
+            errored += titleErrored;
+        }
+
         _logger.Info("Pre-import tag: {SourceId} tagged={Tagged} skipped_weak_match={Skipped} tag_write_failed={TagWriteFailed}",
             sourceId, tagged, skipped, errored);
         return new TaggingResult(tagged, skipped, errored);
+    }
+
+    private static bool IsTitleFallbackEligible(Album album) =>
+        string.Equals(album.AlbumType, "Single", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(album.AlbumType, "EP", StringComparison.OrdinalIgnoreCase);
+
+    private (int Tagged, int Errored) TryTitleDrivenTagging(
+        List<LocalTrack> localTracks,
+        Album album,
+        AlbumRelease? albumRelease,
+        bool stripFeaturedArtists,
+        string sourceId,
+        CancellationToken ct)
+    {
+        AlbumRelease? release = albumRelease
+            ?? album.AlbumReleases?.Value?.FirstOrDefault(r => r.Monitored)
+            ?? album.AlbumReleases?.Value?.FirstOrDefault();
+        List<Track>? tracks = release?.Tracks?.Value;
+        if (release == null || tracks is not { Count: > 0 })
+            return (0, 0);
+
+        string? artistName = album.Artist?.Value?.Name;
+        List<string> localTitles = localTracks.Select(lt =>
+        {
+            // A present-but-foreign artist tag means a same-titled track by
+            // someone else — exclude it rather than tag across artists.
+            string? artistTag = lt.FileTrackInfo?.ArtistTitle;
+            if (!string.IsNullOrWhiteSpace(artistTag) && !string.IsNullOrWhiteSpace(artistName) &&
+                Fuzz.TokenSetRatio(artistTag.ToLowerInvariant(), artistName.ToLowerInvariant()) < 60)
+            {
+                return string.Empty;
+            }
+
+            string title = lt.FileTrackInfo?.Title ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(title))
+                title = TrackTitleMatcher.TitleFromFilename(Path.GetFileNameWithoutExtension(lt.Path));
+
+            return title;
+        }).ToList();
+
+        Dictionary<int, int> mapping = TrackTitleMatcher.Match(localTitles, tracks.Select(t => t.Title).ToList());
+        if (mapping.Count == 0)
+            return (0, 0);
+
+        _logger.Info("Pre-import tag: album-level match failed but {Matched}/{FileCount} track title(s) match release '{Release}' — tagging by title for {SourceId}",
+            mapping.Count, localTracks.Count, release.Title, sourceId);
+
+        int tagged = 0;
+        int errored = 0;
+        foreach ((int localIndex, int wantedIndex) in mapping)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (TryTagSingleFile(localTracks[localIndex], tracks[wantedIndex], album, release, stripFeaturedArtists))
+                tagged++;
+            else
+                errored++;
+        }
+
+        return (tagged, errored);
     }
 
     private bool TryTagSingleFile(LocalTrack localTrack, Track track, Album album, AlbumRelease? albumRelease, bool stripFeaturedArtists)

--- a/src/Sleezer/Core/PostProcessing/TrackTitleMatcher.cs
+++ b/src/Sleezer/Core/PostProcessing/TrackTitleMatcher.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+using FuzzySharp;
+using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
+
+namespace NzbDrone.Plugin.Sleezer.Core.PostProcessing;
+
+/// <summary>
+/// Title-driven track matching for downloads whose album-level identification
+/// cannot pass — a single pulled out of an album share carries that album's
+/// tag, so album distance always fails while the track itself is exactly right.
+/// </summary>
+public static partial class TrackTitleMatcher
+{
+    public const int DefaultThreshold = 85;
+
+    /// <summary>
+    /// Greedy unique assignment of local titles onto wanted track titles. A
+    /// pair only matches at or above the similarity threshold and with
+    /// agreeing remix/variant signatures. Returns local→wanted indices for the
+    /// files that matched; unmatched files are simply absent.
+    /// </summary>
+    public static Dictionary<int, int> Match(IReadOnlyList<string?> localTitles, IReadOnlyList<string?> wantedTitles, int threshold = DefaultThreshold)
+    {
+        Dictionary<int, int> mapping = [];
+        HashSet<int> claimed = [];
+
+        for (int i = 0; i < localTitles.Count; i++)
+        {
+            string local = Normalize(localTitles[i]);
+            if (local.Length == 0)
+                continue;
+
+            int best = -1;
+            int bestScore = threshold - 1;
+            for (int j = 0; j < wantedTitles.Count; j++)
+            {
+                if (claimed.Contains(j))
+                    continue;
+
+                string wanted = Normalize(wantedTitles[j]);
+                if (wanted.Length == 0 || SlskdTextProcessor.RemixSignaturesConflict(wantedTitles[j], localTitles[i]))
+                    continue;
+
+                int score = Fuzz.TokenSetRatio(local, wanted);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    best = j;
+                }
+            }
+
+            if (best >= 0)
+            {
+                mapping[i] = best;
+                claimed.Add(best);
+            }
+        }
+
+        return mapping;
+    }
+
+    /// <summary>
+    /// Derives a comparable title from an extension-less filename: strips the
+    /// leading track numbering and any "Artist - " prefix segments.
+    /// </summary>
+    public static string TitleFromFilename(string? filenameWithoutExtension)
+    {
+        if (string.IsNullOrWhiteSpace(filenameWithoutExtension))
+            return string.Empty;
+
+        string title = LeadingTrackNumberRegex().Replace(filenameWithoutExtension.Trim(), "");
+        int dash = title.LastIndexOf(" - ", StringComparison.Ordinal);
+        if (dash >= 0 && dash + 3 < title.Length)
+            title = title[(dash + 3)..];
+
+        return title.Trim();
+    }
+
+    private static string Normalize(string? title) =>
+        SlskdTextProcessor.StripPunctuation(title).ToLowerInvariant();
+
+    [GeneratedRegex(@"^\s*\d{1,4}\s*[-._)\]]*\s*")]
+    private static partial Regex LeadingTrackNumberRegex();
+}

--- a/src/Sleezer/Core/PostProcessing/TrackTitleMatcher.cs
+++ b/src/Sleezer/Core/PostProcessing/TrackTitleMatcher.cs
@@ -21,39 +21,37 @@ public static partial class TrackTitleMatcher
     /// </summary>
     public static Dictionary<int, int> Match(IReadOnlyList<string?> localTitles, IReadOnlyList<string?> wantedTitles, int threshold = DefaultThreshold)
     {
-        Dictionary<int, int> mapping = [];
-        HashSet<int> claimed = [];
-
+        // Score every viable pair first, then assign best-first: greedy
+        // in-array-order assignment let a mediocre earlier file claim the slot
+        // an exact later file should have won.
+        List<(int Local, int Wanted, int Score)> candidates = [];
         for (int i = 0; i < localTitles.Count; i++)
         {
             string local = Normalize(localTitles[i]);
             if (local.Length == 0)
                 continue;
 
-            int best = -1;
-            int bestScore = threshold - 1;
             for (int j = 0; j < wantedTitles.Count; j++)
             {
-                if (claimed.Contains(j))
-                    continue;
-
                 string wanted = Normalize(wantedTitles[j]);
                 if (wanted.Length == 0 || SlskdTextProcessor.RemixSignaturesConflict(wantedTitles[j], localTitles[i]))
                     continue;
 
                 int score = Fuzz.TokenSetRatio(local, wanted);
-                if (score > bestScore)
-                {
-                    bestScore = score;
-                    best = j;
-                }
+                if (score >= threshold)
+                    candidates.Add((i, j, score));
             }
+        }
 
-            if (best >= 0)
-            {
-                mapping[i] = best;
-                claimed.Add(best);
-            }
+        Dictionary<int, int> mapping = [];
+        HashSet<int> claimedWanted = [];
+        foreach ((int local, int wanted, _) in candidates.OrderByDescending(c => c.Score))
+        {
+            if (mapping.ContainsKey(local) || claimedWanted.Contains(wanted))
+                continue;
+
+            mapping[local] = wanted;
+            claimedWanted.Add(wanted);
         }
 
         return mapping;

--- a/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
+++ b/src/Sleezer/Indexers/Soulseek/SlskdTextProcessor.cs
@@ -408,7 +408,7 @@ namespace NzbDrone.Plugin.Sleezer.Indexers.Soulseek
         [GeneratedRegex(@"[\(\[\{].*?[\)\]\}]", RegexOptions.Compiled)]
         private static partial Regex BracketedContentRegex();
 
-        [GeneratedRegex(@"\b(remix(es)?|rmx|re-?work(ed)?|bootleg|vip|flip|edit)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        [GeneratedRegex(@"\b(remix(es)?|rmx|re-?work(ed)?|bootleg|vip|flip|edit|instrumental|acapella|karaoke)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
         private static partial Regex RemixKeywordRegex();
     }
 }

--- a/tests/Sleezer.Tests/Sleezer.Tests.csproj
+++ b/tests/Sleezer.Tests/Sleezer.Tests.csproj
@@ -34,6 +34,8 @@
              LinkBase="SourceUnderTest" />
     <Compile Include="..\..\src\Sleezer\Core\PostProcessing\FfmpegErrorFormatter.cs"
              LinkBase="SourceUnderTest" />
+    <Compile Include="..\..\src\Sleezer\Core\PostProcessing\TrackTitleMatcher.cs"
+             LinkBase="SourceUnderTest" />
     <Compile Include="..\..\src\Sleezer\Core\Tidal\TidalPathSanitizer.cs"
              LinkBase="SourceUnderTest" />
     <Compile Include="..\..\src\Sleezer\Core\Tidal\TidalArtistMatcher.cs"

--- a/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
+++ b/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Download.History;
+using NzbDrone.Plugin.Sleezer.Core.PostProcessing;
 using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek;
 using NzbDrone.Plugin.Sleezer.Download.Clients.Soulseek.Models;
 using NzbDrone.Plugin.Sleezer.Indexers.Soulseek;
@@ -22,6 +23,7 @@ public class RemixSignatureTests
     [InlineData("Nevermind (Remastered)", null)]
     [InlineData("Love Who You Love (Radio Edit)", "radio")]
     [InlineData("Album (VIP)", "")]
+    [InlineData("Album (Instrumental)", "")]
     [InlineData("Album (2014) [FLAC]", null)]
     public void ExtractRemixSignature_identifies_remix_qualifiers(string title, string? expected)
     {
@@ -95,5 +97,54 @@ public class RetryDownloadIdTests
     public void StripRetrySuffix_recovers_the_content_hash(string input, string expected)
     {
         Assert.Equal(expected, SlskdDownloadItem.StripRetrySuffix(input));
+    }
+}
+
+public class TrackTitleMatcherTests
+{
+    [Fact]
+    public void Match_maps_a_single_pulled_from_an_album_share()
+    {
+        Dictionary<int, int> mapping = TrackTitleMatcher.Match(["I Luv U"], ["I Luv U"]);
+        Assert.Equal(0, Assert.Single(mapping).Value);
+    }
+
+    [Fact]
+    public void Match_excludes_remix_files_but_keeps_the_original()
+    {
+        Dictionary<int, int> mapping = TrackTitleMatcher.Match(["solo", "solo (KETTAMA remix)"], ["solo"]);
+        Assert.Single(mapping);
+        Assert.Equal(0, mapping[0]);
+    }
+
+    [Fact]
+    public void Match_rejects_instrumental_variants_of_the_wanted_track()
+    {
+        Assert.Empty(TrackTitleMatcher.Match(["Me Myself and I Instrumental"], ["Me, Myself & I"]));
+    }
+
+    [Fact]
+    public void Match_rejects_unrelated_titles()
+    {
+        Assert.Empty(TrackTitleMatcher.Match(["Lethal Industry"], ["I Luv U"]));
+    }
+
+    [Fact]
+    public void Match_assigns_each_wanted_track_once()
+    {
+        Dictionary<int, int> mapping = TrackTitleMatcher.Match(["scared", "scared"], ["scared"]);
+        Assert.Single(mapping);
+    }
+
+    [Theory]
+    [InlineData("03. I Luv U", "I Luv U")]
+    [InlineData("0101 - G‐Eazy - Me Myself and I", "Me Myself and I")]
+    [InlineData("04 solo", "solo")]
+    [InlineData("01 - scared", "scared")]
+    [InlineData("Fred again.. - Victory Lap", "Victory Lap")]
+    [InlineData("", "")]
+    public void TitleFromFilename_strips_numbering_and_artist_prefixes(string input, string expected)
+    {
+        Assert.Equal(expected, TrackTitleMatcher.TitleFromFilename(input));
     }
 }

--- a/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
+++ b/tests/Sleezer.Tests/SlskdLiveAuditFollowupTests.cs
@@ -136,6 +136,14 @@ public class TrackTitleMatcherTests
         Assert.Single(mapping);
     }
 
+    [Fact]
+    public void Match_prefers_the_best_score_regardless_of_file_order()
+    {
+        Dictionary<int, int> mapping = TrackTitleMatcher.Match(["scarred", "scared"], ["scared"]);
+        Assert.Single(mapping);
+        Assert.Equal(0, mapping[1]);
+    }
+
     [Theory]
     [InlineData("03. I Luv U", "I Luv U")]
     [InlineData("0101 - G‐Eazy - Me Myself and I", "Me Myself and I")]


### PR DESCRIPTION
Soulseek search responses contain only the files that matched the query, so a single grabbed from someone's album rip arrives as one correct track wearing the album's tag. Album-level identification can never pass for those (57.7% vs the 80% requirement on a live grab), the tagger rightly refuses to overwrite tags on a weak match since #59, and the download parks at importFailed — three of them are sitting in the queue right now (I Luv U, Victory Lap, Ambery).

When album distance fails and the target is a Single or EP, fall back to per-track title matching against the target release:

- Greedy unique title assignment at >=85 TokenSetRatio via the new `TrackTitleMatcher`.
- The remix/variant conflict check from #59 applies per pair, so `solo (KETTAMA remix)` can never tag as `solo`. Variant keywords now also cover instrumental/acapella/karaoke — same different-recording semantics, and they'd otherwise ride the token-subset match straight through.
- A present-but-foreign artist tag excludes the file: a same-titled track by another artist must not tag across artists.
- Untagged files fall back to filename-derived titles (leading track numbers and artist prefixes stripped).

Scoped to Single/EP targets deliberately: full albums arrive as folders with coherent tags and already pass normal identification; widening title-driven tagging to them would trade a real failure mode for a speculative one.

## Tests

`TrackTitleMatcherTests` (mapping, remix/instrumental exclusion, unique assignment, filename stripping) plus new variant-keyword rows in the remix-signature matrix. 220 total, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tagging for Single and EP releases by falling back to per-track, title-based matching when album-level identification finds no matches.
  * Enhanced track matching using normalized titles from metadata or filenames (including stripping numbering/artist prefixes).

* **Bug Fixes**
  * Improved remix/instrumental handling by broadening remix qualifier detection and refining matching to avoid remix/variant conflicts.

* **Tests**
  * Added coverage for title matching and filename normalization to ensure correct, one-to-one track pairing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->